### PR TITLE
`hetimazipql` cask is gone

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -258,7 +258,6 @@ cask install suspicious-package
 cask install packages
 cask install qlcolorcode
 cask install qlimagesize
-cask install hetimazipql
 cask install iterm2
 cask install gyazo
 cask install 0xed

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -263,7 +263,6 @@ brew cask install suspicious-package
 brew cask install packages
 brew cask install qlcolorcode
 brew cask install qlimagesize
-brew cask install hetimazipql
 brew cask install iterm2
 brew cask install gyazo
 brew cask install 0xed


### PR DESCRIPTION
See also:
> hetimazipql: removed for too few downloads

- https://github.com/Homebrew/homebrew-cask/commit/d9da0654bfb80697b825975c03ebb43be9aa219e