### PR TITLE
Customize "cursor shape" like my iTerm2 configuration

### DIFF
--- a/.vim/rc/vimrc
+++ b/.vim/rc/vimrc
@@ -689,3 +689,7 @@ endfunction
 
 autocmd! User FzfStatusLine call <SID>fzf_statusline()
 " }}}
+
+" cursor_shape {{{
+set guicursor=n-v-o-c:hor10,i-ci-ve-sm:ver20,r-cr:block,a:blinkwait1000-blinkon1000-blinkoff1000
+" }}}

--- a/.vim/rc/vimrc
+++ b/.vim/rc/vimrc
@@ -691,5 +691,9 @@ autocmd! User FzfStatusLine call <SID>fzf_statusline()
 " }}}
 
 " cursor_shape {{{
+let &t_SI = "\<Esc>]50;CursorShape=1\x7"
+let &t_SR = "\<Esc>]50;CursorShape=0\x7"
+let &t_EI = "\<Esc>]50;CursorShape=2\x7"
+
 set guicursor=n-v-o-c:hor10,i-ci-ve-sm:ver20,r-cr:block,a:blinkwait1000-blinkon1000-blinkoff1000
 " }}}


### PR DESCRIPTION
# See also:
## nvim
- https://github.com/neovim/neovim/wiki/FAQ
- https://github.com/neovim/neovim/wiki/FAQ#nvim-shows-weird-symbols-2-q-when-changing-modes
- https://github.com/neovim/neovim/wiki/FAQ#how-to-change-cursor-shape-in-the-terminal

## vim
- https://iterm2.com/documentation/2.1/documentation-one-page.html
- https://vim.fandom.com/wiki/Change_cursor_shape_in_different_modes
- https://postd.cc/vim-galore-4/