### PR TITLE
Install AdoptOpenJDK

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -233,6 +233,7 @@ cask install slack
 cask install skitch
 cask install geektool
 cask install xquartz
+cask install adoptopenjdk
 cask install java
 cask install java8
 cask install skype

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -238,6 +238,7 @@ brew cask install slack
 brew cask install skitch
 brew cask install geektool
 brew cask install xquartz
+brew cask install adoptopenjdk
 brew cask install java
 brew cask install java8
 brew cask install skype


### PR DESCRIPTION
Fix the Error:
```
sleuthkit: Java is required to install this formula.
Install AdoptOpenJDK with Homebrew Cask:
  brew cask install adoptopenjdk
Error: An unsatisfied requirement failed this build.
```