### PR TITLE
Install `sleuthkit` with Homebrew explicitly

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -18,6 +18,12 @@ unlink neovim
 update
 upgrade --fetch-HEAD
 
+# sleuthkit
+cask install adoptopenjdk
+cask install java
+cask install java8
+install sleuthkit
+
 install git
 install tig
 install hub
@@ -233,9 +239,6 @@ cask install slack
 cask install skitch
 cask install geektool
 cask install xquartz
-cask install adoptopenjdk
-cask install java
-cask install java8
 cask install skype
 cask install knock
 cask install licecap

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -23,6 +23,12 @@ if ! [[ $(brew info neovim | grep 'Not installed') ]]; then brew unlink neovim; 
 brew update
 brew upgrade --fetch-HEAD
 
+# sleuthkit
+brew cask install adoptopenjdk
+brew cask install java
+brew cask install java8
+brew install sleuthkit
+
 brew install git
 brew install tig
 brew install hub
@@ -238,9 +244,6 @@ brew cask install slack
 brew cask install skitch
 brew cask install geektool
 brew cask install xquartz
-brew cask install adoptopenjdk
-brew cask install java
-brew cask install java8
 brew cask install skype
 brew cask install knock
 brew cask install licecap


### PR DESCRIPTION
It seems to some command depends on `sleuthkit`.
Since it is cumbersome to find out which commands are depends on it, try installing `sleuthkit` explicitly to fix the error.

Error was:
```
sleuthkit: Java is required to install this formula.
Install AdoptOpenJDK with Homebrew Cask:
  brew cask install adoptopenjdk
Error: An unsatisfied requirement failed this build.
```