### PR TITLE
Use `adoptopenjdk8` instead of `java8`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -21,7 +21,7 @@ upgrade --fetch-HEAD
 # sleuthkit
 cask install adoptopenjdk
 cask install java
-cask install java8
+cask install adoptopenjdk8
 install sleuthkit
 
 install git

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -26,7 +26,7 @@ brew upgrade --fetch-HEAD
 # sleuthkit
 brew cask install adoptopenjdk
 brew cask install java
-brew cask install java8
+brew cask install adoptopenjdk8
 brew install sleuthkit
 
 brew install git


### PR DESCRIPTION
`java8` is no longer missing.
```
$ brew cask info java8
Error: Cask 'java8' is unavailable: No Cask with this name exists.
```

`android-sdk` depends on `adoptopenjdk8 ` intead of `java8`.
```
$ brew cask info android-sdk
android-sdk: 4333796
https://developer.android.com/index.html
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/android-sdk.rb
==> Name
android-sdk
==> Artifacts
/usr/local/Caskroom/android-sdk/4333796/tools/android (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/archquery (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/avdmanager (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/jobb (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/lint (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/monkeyrunner (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/screenshot2 (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/sdkmanager (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/uiautomatorviewer (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/emulator (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/emulator-check (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/mksdcard (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/monitor (Binary)
==> Caveats
You can control android sdk packages via the sdkmanager command.
You may want to add to your profile:

  'export ANDROID_SDK_ROOT="/usr/local/share/android-sdk"'

android-sdk requires Java 8. You can install it with:
  brew cask install homebrew/cask-versions/adoptopenjdk8

machupicchubetas-MacBook-Pro:dotfiles machupicchubeta$ brew cask info adoptopenjdk8
adoptopenjdk8: 8,222:b10
https://adoptopenjdk.net/
Not installed
From: https://github.com/Homebrew/homebrew-cask-versions/blob/master/Casks/adoptopenjdk8.rb
==> Name
AdoptOpenJDK 8
==> Artifacts
OpenJDK8U-jdk_x64_mac_hotspot_8u222b10.pkg (Pkg)
```

`android-sdk` previously required `java8`.
- https://github.com/machupicchubeta/dotfiles/commit/b3c72c73baf94d183d1c8b53bbc38ae93a8bfbef#diff-c7214f6b3e175bb89ac4600efdf6c64a