### PR TITLE
Seems to be unnecessary `unlink` :put_litter_in_its_place:

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,10 +11,6 @@ tap InstantClientTap/instantclient
 tap universal-ctags/universal-ctags
 tap heroku/brew
 
-unlink macvim
-unlink vim
-unlink neovim
-
 update
 upgrade --fetch-HEAD
 

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -16,10 +16,6 @@ brew tap InstantClientTap/instantclient
 brew tap universal-ctags/universal-ctags
 brew tap heroku/brew
 
-if ! [[ $(brew info macvim | grep 'Not installed') ]]; then brew unlink macvim; fi
-if ! [[ $(brew info vim | grep 'Not installed') ]]; then brew unlink vim; fi
-if ! [[ $(brew info neovim | grep 'Not installed') ]]; then brew unlink neovim; fi
-
 brew update
 brew upgrade --fetch-HEAD
 


### PR DESCRIPTION
I don't have any trouble without it.
It seems to be linked automatically after installed.