### PR TITLE
Need `universal-ctags` install with `HEAD`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -87,7 +87,7 @@ install fontforge
 install lastpass-cli
 install p7zip
 install pick
-install universal-ctags
+install universal-ctags --HEAD
 install tree
 install packer
 install packer-completion

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -92,7 +92,7 @@ brew install fontforge
 brew install lastpass-cli
 brew install p7zip
 brew install pick
-brew install universal-ctags
+brew install universal-ctags --HEAD
 brew install tree
 brew install packer
 brew install packer-completion


### PR DESCRIPTION
Error was:
```
Error: universal-ctags/universal-ctags/universal-ctags is a head-only formula
```

Ref.
- https://github.com/universal-ctags/homebrew-universal-ctags#usage