### PR TITLE
Add `ZPLUG_HOME`

### DIFF
--- a/.dotfiles/.exports_zsh
+++ b/.dotfiles/.exports_zsh
@@ -9,3 +9,6 @@ test -e "$(brew --prefix fzf)/shell/key-bindings.zsh" && source "$(brew --prefix
 test -e "$(brew --prefix zsh-autosuggestions)/share/zsh-autosuggestions/zsh-autosuggestions.zsh" && source "$(brew --prefix zsh-autosuggestions)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 test -e "$(brew --prefix zsh-syntax-highlighting)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" && source "$(brew --prefix zsh-syntax-highlighting)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 test -e '/usr/local/share/zsh/site-functions/_aws' && source '/usr/local/share/zsh/site-functions/_aws'
+
+export ZPLUG_HOME=/usr/local/opt/zplug
+source $ZPLUG_HOME/init.zsh


### PR DESCRIPTION
```
$ brew info zplug
zplug: stable 2.4.2, HEAD
The next-generation plugin manager for zsh
https://zplug.sh/
/usr/local/Cellar/zplug/2.4.2 (198 files, 369.7KB) *
  Built from source on 2019-10-23 at 02:17:32
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/zplug.rb
==> Options
--HEAD
	Install HEAD version
==> Caveats
In order to use zplug, please add the following to your .zshrc:
  export ZPLUG_HOME=/usr/local/opt/zplug
  source $ZPLUG_HOME/init.zsh
==> Analytics
install: 1,085 (30 days), 2,602 (90 days), 9,043 (365 days)
install_on_request: 1,084 (30 days), 2,597 (90 days), 9,010 (365 days)
build_error: 0 (30 days)
```