### PR TITLE
Remove `pip2`

### DIFF
--- a/bin/upgrade_pips.sh
+++ b/bin/upgrade_pips.sh
@@ -3,9 +3,6 @@
 # pip
 pip install --upgrade pip
 
-# pip2
-pip2 install pynvim
-
 # pip3
 pip3 install --upgrade pip setuptools wheel
 pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install -U


### PR DESCRIPTION
Python2 is no longer used.

See also:
- https://github.com/machupicchubeta/laptop/commit/1d692f7d956c14ed922e72fe70ef59b358891ad9#diff-140c1f12feeb2c52dfbeb2da6066a73a