### PR TITLE
Whitespaces gone

### DIFF
--- a/bin/setup_ruby.sh
+++ b/bin/setup_ruby.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-latest_ruby_version=$(rbenv install -l | grep -E '^\s+(\d+\.\d+)\.\d+$' | tail -n 1)
+latest_ruby_version=$(rbenv install -l | grep -E '^(\d+\.\d+)\.\d+$' | tail -n 1)
 rbenv install --skip-existing $latest_ruby_version
 rbenv global $latest_ruby_version
 rbenv rehash


### PR DESCRIPTION
```
$ rbenv install -l | grep -E '^(\d+\.\d+)\.\d+$' | tail -n 1
2.6.5
```