### PR TITLE
Introduce "docutils"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -97,6 +97,7 @@ brew install automake
 brew install fontforge
 brew install p7zip
 brew install pick
+brew install docutils
 brew install universal-ctags --HEAD
 brew link universal-ctags
 brew install tree


### PR DESCRIPTION
Avoid upgrade error on "universal-ctags".
"universal-ctags" seems to be depends on "docutils".
- https://github.com/universal-ctags/ctags#manual

Error was:
```
==> Upgrading 1 outdated package:
universal-ctags/universal-ctags/universal-ctags HEAD-be621aec6f0bf23eb8d47528f9cd6fdd7f25e4ba
==> Upgrading universal-ctags/universal-ctags/universal-ctags
Error: An exception occurred within a child process:
  RuntimeError: /usr/local/opt/docutils not present or broken
Please reinstall docutils. Sorry :(
```