### PR TITLE
Enable compilers to use `zlib` that installed via Homebrew

### DIFF
--- a/.dotfiles/.exports
+++ b/.dotfiles/.exports
@@ -48,6 +48,6 @@ export PYTHONPATH=$(if which pyenv > /dev/null; then echo -n "$(pyenv root)/shim
 export ENHANCD_FILTER=fzf
 export ENHANCD_DOT_ARG='~~'
 
-export LDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/readline/lib"
-export CPPFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/readline/include"
-export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig"
+export LDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/zlib/lib"
+export CPPFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/readline/include -I/usr/local/opt/zlib/include"
+export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig"


### PR DESCRIPTION
```
$ brew info zlib
zlib: stable 1.2.11 (bottled) [keg-only]
General-purpose lossless data-compression library
https://zlib.net/
/usr/local/Cellar/zlib/1.2.11 (12 files, 376.4KB)
  Poured from bottle on 2019-11-05 at 03:25:59
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/zlib.rb
==> Caveats
zlib is keg-only, which means it was not symlinked into /usr/local,
because macOS already provides this software and installing another version in
parallel can cause all kinds of trouble.

For compilers to find zlib you may need to set:
  export LDFLAGS="-L/usr/local/opt/zlib/lib"
  export CPPFLAGS="-I/usr/local/opt/zlib/include"

For pkg-config to find zlib you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"

==> Analytics
install: 29,013 (30 days), 78,977 (90 days), 240,720 (365 days)
install_on_request: 28,188 (30 days), 76,578 (90 days), 226,994 (365 days)
build_error: 0 (30 days)
```