### PR TITLE
Good bye "google-featured-photos"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -291,7 +291,6 @@ brew cask install docker
 brew cask install 1password
 brew cask install gpg-suite
 brew cask install fliqlo
-brew cask install google-featured-photos
 brew cask install google-earth-pro
 brew cask install zoomus
 brew cask install spotify


### PR DESCRIPTION
- https://plus.google.com/
- https://plus.google.com/featuredphotos
> Google+ is no longer available for consumer (personal) and brand accounts

It seems that is no longer maintained.
The web page "https://plus.google.com/featuredphotos" has been redirected on the page above also.