### PR TITLE
Kick out `clamav`, no longer used :put_litter_in_its_place:

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -197,7 +197,6 @@ brew install fzf
 brew install coffeescript
 brew install zlib
 brew install awscli
-brew install clamav
 brew install whois
 brew install bettercap
 brew install lsd


### PR DESCRIPTION
It was used for a project at work, but removed dependency.