### PR TITLE
Ensure to load ".zplugrc" in ".zshrc"

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,4 @@
-source .zplugrc
+source $HOME/.zplugrc
 
 # Path to your oh-my-zsh installation.
 export ZSH=$HOME/.oh-my-zsh


### PR DESCRIPTION
Avoid load error via `ghq look` command.
Error was:
```
GHQ_ROOT=~/Repositories ghq look machupicchubeta/laptop
/Users/machupicchubeta/.zshrc:source:1: no such file or directory: .zplugrc
```