### PR TITLE
Use "Shell Parameter Expansion" than "Tilde Expansion"

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -76,12 +76,12 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
-for file in ~/.dotfiles/.{exports,exports_zsh,exports_compiler_options,extra,aliases,aliases_zsh,functions,private}; do
+for file in $HOME/.dotfiles/.{exports,exports_zsh,exports_compiler_options,extra,aliases,aliases_zsh,functions,private}; do
   [ -r "$file" ] && source "$file"
 done
 
 function box_name {
-  [ -f ~/.box-name ] && cat ~/.box-name || echo $SHORT_HOST || echo $HOST
+  [ -f $HOME/.box-name ] && cat $HOME/.box-name || echo $SHORT_HOST || echo $HOST
 }
 
 # spaceship-prompt


### PR DESCRIPTION
Ref.
- https://www.gnu.org/software/bash/manual/html_node/Shell-Expansions.html
- https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
- https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html