### PR TITLE
Ignore `.bundle/cache/**` on git

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,2 +1,3 @@
 tags
 vendor/bundle/**
+.bundle/cache/**


### PR DESCRIPTION
The directory seems to be a "global cache directory", maybe.
- https://github.com/rubygems/bundler/search?p=1&q=global_cache&type=Commits