### PR TITLE
Drop unused vim config

### DIFF
--- a/.vim/rc/vimrc
+++ b/.vim/rc/vimrc
@@ -96,10 +96,6 @@ let t:cwd = getcwd()
 set secure
 
 call s:source_rc('emmet')
-
-" quickrun key-mapping
-silent! nmap <unique> <Space>r <Plug>(quickrun)
-
 call s:source_rc('rspec')
 call s:source_rc('submode')
 call s:source_rc('showmarks')


### PR DESCRIPTION
`vim-quickrun` is no longer used. :put_litter_in_its_place: