### PR TITLE
Unnecessary to `set nocompatible` :put_litter_in_its_place:

### DIFF
--- a/.vim/rc/vimrc
+++ b/.vim/rc/vimrc
@@ -1,8 +1,3 @@
-" Make vim more useful
-if &compatible
-  set nocompatible
-endif
-
 " source_rc {{{
 function! s:source_rc(path, ...) abort
   let use_global = get(a:000, 0, !has('vim_starting'))


### PR DESCRIPTION
See also:
- https://qiita.com/yu_suke1994/items/e0a19574994a57c8fe17
- https://blog.unasuke.com/2014/set-nocompatible-in-vimrc/
- https://vim-jp.org/vim-users-jp/2010/10/28/Hack-179.html
- https://vim-jp.org/vimdoc-ja/options.html#'compatible'