### PR TITLE
Unnecessary to install "mono-mdk" individually

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -283,7 +283,6 @@ brew cask install zoomus
 brew cask install spotify
 brew cask install chromedriver
 brew cask install microsoft-remote-desktop-beta
-brew cask install mono-mdk
 brew cask install dotnet
 brew cask install visual-studio
 brew cask install visual-studio-code


### PR DESCRIPTION
"mono-mdk" which "visual-studio" depends on is installed at the same time.

See also:
- https://github.com/Homebrew/homebrew-cask/issues/59740
- https://github.com/Homebrew/homebrew-cask/issues/60110
- https://github.com/Homebrew/homebrew-cask-versions/pull/7145
- https://github.com/Homebrew/homebrew-cask/pull/60928