### PR TITLE
Enable to `sudo` authenticate with touch id

### DIFF
--- a/bin/enable_to_sudo_authenticate_with_touch_id.sh
+++ b/bin/enable_to_sudo_authenticate_with_touch_id.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+sudo chmod +w /etc/pam.d/sudo
+if ! grep -Eq '^auth\s.*\spam_tid\.so$' /etc/pam.d/sudo; then
+    ( set -e; set -o pipefail
+      # Add "pam_tid.so" to a first authentication
+      pam_sudo=$(awk 'fixed||!/^auth /{print} !fixed&&/^auth/{print "auth       sufficient     pam_tid.so";print;fixed=1}' /etc/pam.d/sudo)
+      sudo tee /etc/pam.d/sudo <<<"$pam_sudo"
+    )
+fi


### PR DESCRIPTION
Add "pam_tid.so" to a first authentication in "/etc/pam.d/sudo".

See also:
- https://dev.classmethod.jp/etc/mac-terminal-sudo-touch-id/
- https://gist.github.com/kawaz/d95fb3b547351e01f0f3f99783180b9f