### PR TITLE
Introduce `gti` :car:

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -63,6 +63,7 @@ brew install neovim
 brew install bash-completion
 brew install imagemagick
 brew install sl
+brew install gti
 brew install bash
 brew install heroku
 brew install pyenv


### PR DESCRIPTION
```
$ brew info gti
gti: stable 1.7.0 (bottled), HEAD
ASCII-art displaying typo-corrector for commands
https://r-wos.org/hacks/gti
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/gti.rb
==> Options
--HEAD
  Install HEAD version
==> Analytics
install: 159 (30 days), 405 (90 days), 1,202 (365 days)
install-on-request: 157 (30 days), 399 (90 days), 1,181 (365 days)
build-error: 0 (30 days)
```