### PR TITLE
Introduce "LadioCast"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -8,6 +8,8 @@ mas install 497799835 # Xcode
 sudo xcodebuild -license
 xcode-select --install
 
+mas install 411213048 # LadioCast
+
 brew tap thoughtbot/formulae
 brew tap homebrew/cask-versions
 brew tap homebrew/services


### PR DESCRIPTION
- https://apps.apple.com/us/app/ladiocast/id411213048?mt=12

> LadioCast is a software running on Mac OS X to stream digital audio such as Internet radio program.
