### PR TITLE
Enable to install the latest Node.js LTS and Current versions

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -43,7 +43,7 @@ brew install mysql
 brew install redis
 brew install memcached
 brew install node
-brew install node-build
+brew install node-build --HEAD
 brew install nodenv
 brew install watchman
 brew install sqlite


### PR DESCRIPTION
I tried it and it seems that I need the HEAD version of node-build.