### PR TITLE
Re-introduce "osquery " via "Homebrew Cask"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -73,7 +73,6 @@ brew install pyenv
 brew install jq
 brew install ansible
 brew install watch
-brew install osquery
 brew install direnv
 brew install coreutils
 brew install gnu-sed
@@ -304,6 +303,7 @@ brew cask install aerial
 brew cask install figma
 brew cask install miro-formerly-realtimeboard
 brew cask install amazon-chime
+brew cask install osquery
 
 # fonts
 brew cask install font-fira-code


### PR DESCRIPTION
Refs.
- https://github.com/Homebrew/homebrew-cask/commit/b1b2404f021962214a17c880d732d8d00f392af7
- https://github.com/Homebrew/homebrew-cask/pull/84440
- https://osquery.io

No longer ships "osquery" via "Homebrew".
- https://github.com/Homebrew/homebrew-core/commit/d00c56283ab915727e9dd70b20031ef7f361dcfe
- https://github.com/Homebrew/homebrew-core/pull/54905
- https://github.com/Homebrew/homebrew-core/commit/dbd204dde15de9e594215abe1902eec69024b547
- https://github.com/Homebrew/homebrew-core/pull/60321

Warning is:
> Disabled because it has old, vendored dependencies and cannot use duplicated Homebrew libraries!