### PR TITLE
Use the "aws-cli" installed with `brew` instead of `pip`

### DIFF
--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -14,7 +14,6 @@ pip install --upgrade pip
 # pip3
 pip3 install --upgrade pip setuptools wheel
 pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install -U
-pip3 install awscli
 pip3 install aws-shell
 pip3 install cfn-lint
 pip3 install pynvim


### PR DESCRIPTION
Duplicate installation of "aws-cli" command.
And "aws-cli" command installed with `pip` is an older version.

```
$ pip3 show awscli
Name: awscli
Version: 1.18.151
Summary: Universal Command Line Environment for AWS.
Home-page: http://aws.amazon.com/cli/
Author: Amazon Web Services
Author-email: None
License: Apache License 2.0
Location:
/Users/machupicchubeta/.pyenv/versions/3.8.5/lib/python3.8/site-packages
Requires: PyYAML, docutils, botocore, s3transfer, rsa, colorama
Required-by: aws-shell
```

```
$brew info awscli
awscli: stable 2.0.50 (bottled), HEAD
Official Amazon AWS command-line interface
https://aws.amazon.com/cli/
/usr/local/Cellar/awscli/2.0.50 (11,987 files, 86MB) *
  Poured from bottle on 2020-09-22 at 17:00:13
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/awscli.rb
License: Apache-2.0
==> Dependencies
Required: python@3.8 ✔
==> Options
--HEAD
  Install HEAD version
==> Caveats
The "examples" directory has been installed to:
  /usr/local/share/awscli/examples

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions and functions have been installed to:
  /usr/local/share/zsh/site-functions
==> Analytics
install: 108,257 (30 days), 389,044 (90 days), 1,146,507 (365 days)
install-on-request: 105,766 (30 days), 379,696 (90 days), 1,109,368 (365 days)
build-error: 0 (30 days)
```