### PR TITLE
Introduce "aws-shell" via `brew` instead of `pip`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -204,6 +204,7 @@ brew install mosquitto
 brew install arp-scan
 brew install rustup
 brew install mongodb-community
+brew install aws-shell
 
 # for ruby
 brew install openssl

--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -14,7 +14,6 @@ pip install --upgrade pip
 # pip3
 pip3 install --upgrade pip setuptools wheel
 pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install -U
-pip3 install aws-shell
 pip3 install cfn-lint
 pip3 install pynvim
 /usr/local/bin/pip3 install pynvim


### PR DESCRIPTION
It is enable to install it with `brew`, so I will use it.

```
$ pip3 show aws-shell
Name: aws-shell
Version: 0.2.1
Summary: AWS Shell
Home-page: https://github.com/awslabs/aws-shell
Author: James Saryerwinnie
Author-email: UNKNOWN
License: Apache License 2.0
Location:
/Users/machupicchubeta/.pyenv/versions/3.8.5/lib/python3.8/site-packages
Requires: Pygments, configobj, boto3, awscli, prompt-toolkit
Required-by:
```

```
$ brew info aws-shell
aws-shell: stable 0.2.1 (bottled)
Integrated shell for working with the AWS CLI
https://github.com/awslabs/aws-shell
Not installed
From:
https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/aws-shell.rb
License: Apache-2.0
==> Dependencies
Required: python@3.8 ✔
==> Analytics
install: 628 (30 days), 2,119 (90 days), 10,113 (365 days)
install-on-request: 620 (30 days), 2,101 (90 days), 9,853 (365 days)
build-error: 0 (30 days)
```