### PR TITLE
Change the way that `pip` resolves dependency conflicts

### DIFF
--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -13,7 +13,7 @@ pip install --upgrade --use-feature=2020-resolver pip
 
 # pip3
 pip3 install --upgrade --use-feature=2020-resolver pip setuptools wheel
-pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install -U --use-feature=2020-resolver
+pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install --upgrade --use-feature=2020-resolver
 pip3 install cfn-lint
 pip3 install pynvim
 /usr/local/bin/pip3 install pynvim

--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -9,11 +9,11 @@ pyenv rehash
 eval "$(pyenv init -)"
 
 # pip
-pip install --upgrade pip
+pip install --upgrade --use-feature=2020-resolver pip
 
 # pip3
-pip3 install --upgrade pip setuptools wheel
-pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install -U
+pip3 install --upgrade --use-feature=2020-resolver pip setuptools wheel
+pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install -U --use-feature=2020-resolver
 pip3 install cfn-lint
 pip3 install pynvim
 /usr/local/bin/pip3 install pynvim


### PR DESCRIPTION
Error was:
```
ERROR: After October 2020 you may experience errors when installing or
updating packages. This is because pip will change the way that it
resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages
with the new resolver before it becomes the default.

awscli 1.18.157 requires colorama<0.4.4,>=0.2.5; python_version !=
"3.4", but you'll have colorama 0.4.4 which is incompatible.
awscli 1.18.157 requires docutils<0.16,>=0.10, but you'll have docutils
0.16 which is incompatible.
awscli 1.18.157 requires rsa<=4.5.0,>=3.1.2; python_version != "3.4",
but you'll have rsa 4.6 which is incompatible.
aws-shell 0.2.2 requires prompt-toolkit<1.1.0,>=1.0.0, but you'll have
prompt-toolkit 3.0.8 which is incompatible.
```

See also:
- https://discuss.python.org/t/announcement-pip-20-2-release/4863
