### PR TITLE
Make "GitHub CLI" easy to use with aliases

### DIFF
--- a/.dotfiles/.aliases
+++ b/.dotfiles/.aliases
@@ -82,6 +82,7 @@ alias release_pull_request_name="echo RELEASE_$(date +%Y%m%d_%H%M)"
 alias rprn="echo RELEASE_$(date +%Y%m%d_%H%M)"
 alias release_pull_request="git pull-request -b release -l release"
 alias rpr="git pull-request -b release -l release"
+alias github-cli="gh"
 
 # File size
 alias fs="stat -f \"%z bytes\""


### PR DESCRIPTION
It's easy to forget that the "GitHub CLI" exists, so I try to make it easy to use with aliases.

About "GitHub CLI":
- https://github.com/cli/cli