### PR TITLE
Reduce "zsh" startup time by using a static path to the command

### DIFF
--- a/.dotfiles/.exports_bash
+++ b/.dotfiles/.exports_bash
@@ -1,5 +1,5 @@
 eval "$(direnv hook bash)"
 
-test -e "$(brew --prefix)/etc/bash_completion" && source "$(brew --prefix)/etc/bash_completion"
-test -e "$(brew --prefix fzf)/shell/completion.bash" && source "$(brew --prefix fzf)/shell/completion.bash"
-test -e "$(brew --prefix fzf)/shell/key-bindings.bash" && source "$(brew --prefix fzf)/shell/key-bindings.bash"
+test -e '/usr/local/etc/bash_completion' && source '/usr/local/etc/bash_completion'
+test -e '/usr/local/opt/fzf/shell/completion.bash' && source '/usr/local/opt/fzf/shell/completion.bash'
+test -e '/usr/local/opt/fzf/shell/key-bindings.bash' && source '/usr/local/opt/fzf/shell/key-bindings.bash'

--- a/.dotfiles/.exports_zsh
+++ b/.dotfiles/.exports_zsh
@@ -1,11 +1,11 @@
 eval "$(direnv hook zsh)"
 
-fpath=($(brew --prefix zsh-completions)/share/zsh-completions $fpath)
+fpath=(/usr/local/opt/zsh-completions/share/zsh-completions $fpath)
 
-test -e "$(brew --prefix zsh-navigation-tools)/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh" && source "$(brew --prefix zsh-navigation-tools)/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh"
+test -e '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh' && source '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh'
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
-test -e "$(brew --prefix fzf)/shell/completion.zsh" && source "$(brew --prefix fzf)/shell/completion.zsh"
-test -e "$(brew --prefix fzf)/shell/key-bindings.zsh" && source "$(brew --prefix fzf)/shell/key-bindings.zsh"
-test -e "$(brew --prefix zsh-autosuggestions)/share/zsh-autosuggestions/zsh-autosuggestions.zsh" && source "$(brew --prefix zsh-autosuggestions)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
-test -e "$(brew --prefix zsh-syntax-highlighting)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" && source "$(brew --prefix zsh-syntax-highlighting)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+test -e '/usr/local/opt/fzf/shell/completion.zsh' && source '/usr/local/opt/fzf/shell/completion.zsh'
+test -e '/usr/local/opt/fzf/shell/key-bindings.zsh' && source '/usr/local/opt/fzf/shell/key-bindings.zsh'
+test -e '/usr/local/opt/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh' && source '/usr/local/opt/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh'
+test -e '/usr/local/opt/zsh-syntax-highlighting/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh' && source '/usr/local/opt/zsh-syntax-highlighting/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh'
 test -e '/usr/local/share/zsh/site-functions/_aws' && source '/usr/local/share/zsh/site-functions/_aws'

--- a/.zplugrc
+++ b/.zplugrc
@@ -11,6 +11,6 @@ fi
 
 zplug load
 
-if [ -e $(brew --prefix)/opt/zplug/repos/denysdovhan/spaceship-prompt/spaceship.zsh-theme ] && [ ! -L "$HOME/.oh-my-zsh/themes/spaceship.zsh-theme" ]; then
-  ln -s $(brew --prefix)/opt/zplug/repos/denysdovhan/spaceship-prompt/spaceship.zsh-theme "$HOME/.oh-my-zsh/themes/spaceship.zsh-theme"
+if [ -e /usr/local/opt/zplug/repos/denysdovhan/spaceship-prompt/spaceship.zsh-theme ] && [ ! -L "$HOME/.oh-my-zsh/themes/spaceship.zsh-theme" ]; then
+  ln -s /usr/local/opt/zplug/repos/denysdovhan/spaceship-prompt/spaceship.zsh-theme "$HOME/.oh-my-zsh/themes/spaceship.zsh-theme"
 fi


### PR DESCRIPTION
It takes a long time to start "zsh" if I use `brew --prefix` command to resolve the path to the command.

# Before:
```
$ time ( zsh -i -c exit )
( zsh -i -c exit; )  6.55s user 5.14s system 91% cpu 12.767 total
```

# After:
```
$ time ( zsh -i -c exit )
( zsh -i -c exit; )  0.90s user 0.96s system 85% cpu 2.185 total
```

# I referred to:
- https://qiita.com/vintersnow/items/7343b9bf60ea468a4180#161018%E8%BF%BD%E8%A8%98