### PR TITLE
Use the proper "Homebrew" Formulae name

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -203,7 +203,7 @@ brew install jsonpp
 brew install gh
 brew install mosquitto
 brew install arp-scan
-brew install rustup
+brew install rustup-init
 brew install mongodb-community
 brew install aws-shell
 


### PR DESCRIPTION
It seems "rustup-init" is the proper name in "Homebrew" Formulae.

```
$ brew info rustup

rustup-init: stable 1.22.1 (bottled)
Rust toolchain installer
https://github.com/rust-lang/rustup.rs
/usr/local/Cellar/rustup-init/1.22.1 (7 files, 6.4MB) *
  Poured from bottle on 2020-07-19 at 00:23:28
  From:
  https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/rustup-init.rb
  License: Apache-2.0
  ==> Dependencies
  Build: rust ✘
  ==> Analytics
  install: 2,157 (30 days), 7,795 (90 days), 41,489 (365 days)
  install-on-request: 2,104 (30 days), 7,625 (90 days), 40,828 (365
  days)
  build-error: 0 (30 days)
```

```
$ brew info rustup-init
rustup-init: stable 1.22.1 (bottled)
Rust toolchain installer
https://github.com/rust-lang/rustup.rs
/usr/local/Cellar/rustup-init/1.22.1 (7 files, 6.4MB) *
  Poured from bottle on 2020-07-19 at 00:23:28
  From:
  https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/rustup-init.rb
  License: Apache-2.0
  ==> Dependencies
  Build: rust ✘
  ==> Analytics
  install: 2,157 (30 days), 7,795 (90 days), 41,489 (365 days)
  install-on-request: 2,104 (30 days), 7,625 (90 days), 40,828 (365
  days)
  build-error: 0 (30 days)
```