### PR TITLE
Drop "iTerm2 Shell Integration" :put_litter_in_its_place:

### DIFF
--- a/.dotfiles/.exports_zsh
+++ b/.dotfiles/.exports_zsh
@@ -3,7 +3,6 @@ eval "$(direnv hook zsh)"
 fpath=($HOME/.zfunc /usr/local/opt/zsh-completions/share/zsh-completions $fpath)
 
 test -e '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh' && source '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh'
-test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 test -e '/usr/local/opt/fzf/shell/completion.zsh' && source '/usr/local/opt/fzf/shell/completion.zsh'
 test -e '/usr/local/opt/fzf/shell/key-bindings.zsh' && source '/usr/local/opt/fzf/shell/key-bindings.zsh'
 test -e '/usr/local/opt/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh' && source '/usr/local/opt/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh'


### PR DESCRIPTION
It is no longer used.