### PR TITLE
Avoid `'kubecontext' not found` error in "Spaceship ZSH"

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -118,7 +118,7 @@ SPACESHIP_PROMPT_ORDER=(
   pyenv         # Pyenv section
   dotnet        # .NET section
   ember         # Ember.js section
-  kubecontext   # Kubectl context section
+  kubectl       # Kubectl context section
   terraform     # Terraform workspace section
   time          # Time stamps section
   exec_time     # Execution time


### PR DESCRIPTION
"kubernetes context" has been splitted into two subsections.

# See also:
- https://github.com/denysdovhan/spaceship-prompt/pull/759/commits/5b1624e1f702d76ee395ff0f8e98210f49a3fc88
- https://github.com/denysdovhan/spaceship-prompt/pull/759
- https://github.com/denysdovhan/spaceship-prompt/commit/6319158f19a7bb83a8131da7268213cb636f9653
- https://github.com/denysdovhan/spaceship-prompt/pull/789
