### PR TITLE
Organize "Oh My Zsh" plugins

### DIFF
--- a/.dotfiles/.aliases
+++ b/.dotfiles/.aliases
@@ -119,7 +119,6 @@ alias pumpitup="osascript -e 'set volume 10'"
 alias hax="growlnotify -a 'Activity Monitor' 'System error' -m 'WTF R U DOIN'"
 
 alias b='bundle'
-alias be='bundle exec'
 
 alias test_in_parallel='bundle && rails db:environment:set RAILS_ENV=test; rails parallel:load_schema parallel:rake\[db:migrate\] parallel:rake\[db:seed_fu\] parallel:spec'
 

--- a/.zshrc
+++ b/.zshrc
@@ -47,7 +47,7 @@ HIST_STAMPS="yyyy-mm-dd"
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git z tmux osx vagrant ruby npm gem tmuxinator history docker redis-cli)
+plugins=(bundler docker git history osx redis-cli z)
 autoload -U compinit && compinit
 
 # User configuration

--- a/oh-my-zsh/custom/zshrc-useful.zsh
+++ b/oh-my-zsh/custom/zshrc-useful.zsh
@@ -26,6 +26,8 @@ zstyle ':completion:*:cd:*' tag-order local-directories path-directories
 zstyle ':completion:*' ignore-parents parent pwd ..
 zstyle ':completion:*:sudo:*' command-path /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /usr/X11R6/bin
 zstyle ':completion:*:processes' command 'ps x -o pid,s,args'
+zstyle ':completion:*:*:docker:*' option-stacking yes
+zstyle ':completion:*:*:docker-*:*' option-stacking yes
 
 setopt print_eight_bit
 setopt no_beep


### PR DESCRIPTION
Use only those plugins that I find useful.

# Refs.
- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/bundler
- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/docker
- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git
- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/history
- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/osx
- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/redis-cli
- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/z

- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/bundler#aliases

- https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/docker#settings
- https://github.com/docker/cli/commit/b10fb43048
