### PR TITLE
Recude `compinit` on zsh startup

### DIFF
--- a/.zsh/zshrc-useful.zsh
+++ b/.zsh/zshrc-useful.zsh
@@ -11,9 +11,6 @@ select-word-style default
 zstyle ':zle:*' word-chars " /=;@:{},|"
 zstyle ':zle:*' word-style unspecified
 
-autoload -Uz compinit
-compinit
-
 autoload predict-on
 zle -N predict-on
 zle -N predict-off


### PR DESCRIPTION
# Before
```
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    4        1686.88   421.72   57.11%    689.23   172.31   23.34%  compinit
 2)    2         663.38   331.69   22.46%    663.38   331.69   22.46%  compdump
 3) 1725         238.37     0.14    8.07%    238.37     0.14    8.07%  compdef
 4)   46         286.20     6.22    9.69%    218.95     4.76    7.41%  __zplug::core::sources::call
 5)    1         369.91   369.91   12.52%    154.31   154.31    5.22%  __check__
 6)   13         963.86    74.14   32.63%    138.08    10.62    4.68%  __zplug::core::load::as_plugin
 7)   20         113.77     5.69    3.85%    113.77     5.69    3.85%  __zplug::sources::oh-my-zsh::check
 8)    6          98.49    16.41    3.33%     98.49    16.41    3.33%  compaudit
 9)   24         240.72    10.03    8.15%     79.88     3.33    2.70%  __zplug::core::sources::use_default
10)   24         440.98    18.37   14.93%     74.05     3.09    2.51%  __zplug::core::add::to_zplugs
11)   13          55.57     4.27    1.88%     55.57     4.27    1.88%  __zplug::job::handle::flock

.... (omit) ....

```

```
$ time ( zsh -i -c exit )
( zsh -i -c exit; )  1.63s user 1.68s system 81% cpu 4.042 total
```

# After
```
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)   46         294.01     6.39   21.60%    245.33     5.33   18.02%  __zplug::core::sources::call
 2)    1         396.70   396.70   29.14%    171.89   171.89   12.63%  __check__
 3)   20         122.13     6.11    8.97%    122.13     6.11    8.97%  __zplug::sources::oh-my-zsh::check
 4)   13         176.56    13.58   12.97%    108.18     8.32    7.95%  __zplug::core::load::as_plugin
 5)   24         232.76     9.70   17.10%     84.90     3.54    6.24%  __zplug::core::sources::use_default
 6)    4          81.42    20.36    5.98%     81.42    20.36    5.98%  compaudit
 7)    3         153.45    51.15   11.27%     72.03    24.01    5.29%  compinit
 8)   24         445.19    18.55   32.71%     65.56     2.73    4.82%  __zplug::core::add::to_zplugs
 9)    1          64.34    64.34    4.73%     56.97    56.97    4.19%  __zplug::core::tags::parse
10)   13          48.55     3.73    3.57%     48.55     3.73    3.57%  __zplug::job::handle::flock
11)    1          34.24    34.24    2.52%     34.13    34.13    2.51%  __zplug::base::base::git_version

.... (omit) ....

```

```
$ time ( zsh -i -c exit )
( zsh -i -c exit; )  1.20s user 1.49s system 85% cpu 3.154 total
```
