### PR TITLE
No more limiting `rbenv install -l` to available versions :gem: :sparkles:

### DIFF
--- a/.dotfiles/.functions
+++ b/.dotfiles/.functions
@@ -112,11 +112,6 @@ function extract() {
   fi
 }
 
-# rbenv
-function rbenv_normal_maintenance() {
-  rbenv install -l | grep -E '^\s+(\d+\.\d+)\.\d+$' | awk '{ if ($1 >= 2.4) print $0 }' | sort --reverse
-}
-
 # switch to default branch in git
 function default_branch() {
   git checkout "$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"


### PR DESCRIPTION
`rbnenv instal -l` shows the available versions, already in default.

# See also:
- https://github.com/rbenv/ruby-build/commit/12b17e6e9340f1e6a0d7a516c4be1c383e6c6c73
- https://github.com/rbenv/ruby-build/pull/1402
- http://w.vmeta.jp/tdiary/20200519.html
