### PR TITLE
Introduce "gibo: fast access to .gitignore boilerplates"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -208,6 +208,7 @@ brew install rustup-init
 brew install mongodb-community
 brew install aws-shell
 brew install bottom
+brew install gibo
 
 # for ruby
 brew install openssl


### PR DESCRIPTION
# Refs.
- https://github.com/simonwhitaker/gibo

```
$ brew info gibo

gibo: stable 2.2.4
Access GitHub's .gitignore boilerplates
https://github.com/simonwhitaker/gibo
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gibo.rb
License: Unlicense
==> Analytics
install: 249 (30 days), 777 (90 days), 5,388 (365 days)
install-on-request: 243 (30 days), 749 (90 days), 5,049 (365 days)
build-error: 0 (30 days)
```