### PR TITLE
Load the programming language environment setup codes on zsh startups

### DIFF
--- a/.zplugrc
+++ b/.zplugrc
@@ -24,7 +24,7 @@ zplug "plugins/history", from:oh-my-zsh
 zplug "plugins/osx", from:oh-my-zsh
 zplug "plugins/redis-cli", from:oh-my-zsh
 zplug "plugins/z", from:oh-my-zsh
-zplug "$HOME/.zsh", from:local, use:"*.zsh"
+zplug "$HOME/.zsh", from:local, use:"*.zsh", ignore:"hooks.zsh"
 
 if ! zplug check; then
   zplug install

--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,5 @@
 source $HOME/.zplugrc
+source $HOME/.zsh/hooks.zsh
 
 autoload -U compinit && compinit
 


### PR DESCRIPTION
It seems to need the code that sets up the programming language environment (ex. `eval xxx init -` and `source xxx`) is loaded every time zsh is started, instead of using the zplug cache.

# Before:
```
$ which ruby

/usr/bin/ruby
```

```
$ gem environment

RubyGems Environment:
  - RUBYGEMS VERSION: 3.0.3
  - RUBY VERSION: 2.6.3 (2019-04-16 patchlevel 62) [universal.x86_64-darwin19]
  - INSTALLATION DIRECTORY: /Library/Ruby/Gems/2.6.0
  - USER INSTALLATION DIRECTORY: /Users/machupicchubeta/.gem/ruby/2.6.0
  - RUBY EXECUTABLE: /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
  - GIT EXECUTABLE: /usr/local/bin/git
  - EXECUTABLE DIRECTORY: /usr/local/bin
  - SPEC CACHE DIRECTORY: /Users/machupicchubeta/.gem/specs
  - SYSTEM CONFIGURATION DIRECTORY: /Library/Ruby/Site
  - RUBYGEMS PLATFORMS:
    - ruby
    - universal-darwin-19
  - GEM PATHS:
     - /Library/Ruby/Gems/2.6.0
     - /Users/machupicchubeta/.gem/ruby/2.6.0
     - /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :backtrace => false
     - :bulk_threshold => 1000
     - "gem" => "--no-document"
  - REMOTE SOURCES:
     - https://rubygems.org/
  - SHELL PATH:
     - /Users/machupicchubeta/bin
     - /usr/local/opt/openssl/lib
     - /usr/local/opt/openssl/include
     - /usr/local/opt/openssl/bin
     - /usr/local/opt/libressl/bin
     - /usr/local/opt/curl/bin
     - /usr/local/opt/sqlite/bin
     - /usr/local/opt/nss/bin
     - /usr/local/opt/mysql@5.7/bin
     -
     - /Users/machupicchubeta/bin
     - /Users/machupicchubeta/.cargo/bin
     - /usr/local/bin
     - /usr/local/sbin
     - /usr/local/opt/coreutils/libexec/gnubin
     - /usr/bin
     - /bin
     - /usr/sbin
     - /sbin
     - /opt/X11/bin
     - /usr/local/opt/go/libexec/bin
```

# After:
```
$ which ruby

/Users/machupicchubeta/.rbenv/shims/ruby
```

```
$ gem environment

RubyGems Environment:
  - RUBYGEMS VERSION: 3.1.4
  - RUBY VERSION: 2.7.2 (2020-10-01 patchlevel 137) [x86_64-darwin19]
  - INSTALLATION DIRECTORY: /Users/machupicchubeta/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0
  - USER INSTALLATION DIRECTORY: /Users/machupicchubeta/.gem/ruby/2.7.0
  - RUBY EXECUTABLE: /Users/machupicchubeta/.rbenv/versions/2.7.2/bin/ruby
  - GIT EXECUTABLE: /usr/local/bin/git
  - EXECUTABLE DIRECTORY: /Users/machupicchubeta/.rbenv/versions/2.7.2/bin
  - SPEC CACHE DIRECTORY: /Users/machupicchubeta/.gem/specs
  - SYSTEM CONFIGURATION DIRECTORY: /Users/machupicchubeta/.rbenv/versions/2.7.2/etc
  - RUBYGEMS PLATFORMS:
    - ruby
    - x86_64-darwin-19
  - GEM PATHS:
     - /Users/machupicchubeta/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0
     - /Users/machupicchubeta/.gem/ruby/2.7.0
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :backtrace => false
     - :bulk_threshold => 1000
     - "gem" => "--no-document"
  - REMOTE SOURCES:
     - https://rubygems.org/
  - SHELL PATH:
     - /Users/machupicchubeta/.rbenv/versions/2.7.2/bin
     - /usr/local/Cellar/rbenv/1.1.2/libexec
     - /Users/machupicchubeta/bin
     - /Users/machupicchubeta/.swiftenv/shims
     - /Users/machupicchubeta/.jenv/shims
     - /Users/machupicchubeta/.goenv/shims
     - /Users/machupicchubeta/.nodenv/shims
     - /Users/machupicchubeta/.pyenv/shims
     - /Users/machupicchubeta/.plenv/shims
     - /Users/machupicchubeta/.rbenv/shims
     - /usr/local/opt/openssl/lib
     - /usr/local/opt/openssl/include
     - /usr/local/opt/openssl/bin
     - /usr/local/opt/libressl/bin
     - /usr/local/opt/curl/bin
     - /usr/local/opt/sqlite/bin
     - /usr/local/opt/nss/bin
     - /usr/local/opt/mysql@5.7/bin
     -
     - /Users/machupicchubeta/bin
     - /Users/machupicchubeta/.cargo/bin
     - /usr/local/bin
     - /usr/local/sbin
     - /usr/local/opt/coreutils/libexec/gnubin
     - /usr/bin
     - /bin
     - /usr/sbin
     - /sbin
     - /opt/X11/bin
     - /usr/local/opt/go/libexec/bin
```