### PR TITLE
Disable "safe write" feature to avoid the trouble of `npm start` not detecting changes

### DIFF
--- a/.vim/rc/edit.rc.vim
+++ b/.vim/rc/edit.rc.vim
@@ -154,3 +154,5 @@ if !has('nvim')
   " Allow cursor keys in insert mode
   set esckeys
 endif
+
+set backupcopy=yes


### PR DESCRIPTION
See also:
- https://create-react-app.dev/docs/troubleshooting/#npm-start-doesnt-detect-changes
- https://webpack.js.org/guides/development/#adjusting-your-text-editor
- http://vimdoc.sourceforge.net/htmldoc/options.html#'backupcopy'
