### PR TITLE
No longer available installing "Near Lock" via Homebrew Cask

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -285,7 +285,6 @@ brew cask install google-chrome-canary
 brew cask install soundflower
 brew cask install vlc
 brew cask install chrome-remote-desktop-host
-brew cask install near-lock
 brew cask install vivaldi
 brew cask install lacona
 brew cask install wireshark-chmodbpf


### PR DESCRIPTION
Refs.
- https://github.com/Homebrew/homebrew-cask/commit/eb2e5e05182b230535cccff76baedc05332fa86d
- https://github.com/Homebrew/homebrew-cask/pull/94045

It says:
> has been offline with expired certificate for a week
