### PR TITLE
Make grepped file open in default editor

### DIFF
--- a/.zsh/functions.zsh
+++ b/.zsh/functions.zsh
@@ -132,5 +132,5 @@ function rga-fzf() {
         --preview-window="70%:wrap"
   )" &&
   echo "opening $file" &&
-  xdg-open "$file"
+  $EDITOR "$file"
 }


### PR DESCRIPTION
I assume the command usecase that it is opened with a terminal editor instead of `xdg-open`.
