### PR TITLE
Introduce "mdimagesizemdimporter"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -276,6 +276,7 @@ brew cask install suspicious-package
 brew cask install packages
 brew cask install qlcolorcode
 brew cask install qlimagesize
+brew cask install mdimagesizemdimporter
 brew cask install gyazo
 brew cask install 0xed
 brew cask install alfred


### PR DESCRIPTION
Refs.
- https://github.com/Nyx0uf/qlImageSize#install
- https://github.com/Nyx0uf/qlImageSize#mdimagesize

> mdImageSize
> This is the Spotlight plugin, it displays informations of unsupported images (WebP, bpg) in the Finder's inspector window.
