### PR TITLE
No more need to use `--use-feature=2020-resolver` option in `pip`

### DIFF
--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -9,11 +9,11 @@ pyenv rehash
 eval "$(pyenv init -)"
 
 # pip
-pip install --upgrade --use-feature=2020-resolver pip
+pip install --upgrade pip
 
 # pip3
-pip3 install --upgrade --use-feature=2020-resolver pip setuptools wheel
-pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install --upgrade --use-feature=2020-resolver
+pip3 install --upgrade pip setuptools wheel
+pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install --upgrade
 pip3 install cfn-lint
 pip3 install pynvim
 /usr/local/bin/pip3 install pynvim


### PR DESCRIPTION
Warning was:
```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now the default dependency resolver in pip. This will become an error in pip 21.0.
```
