### PR TITLE
Wipe out broken link aliases

### DIFF
--- a/.bash/.aliases
+++ b/.bash/.aliases
@@ -135,11 +135,6 @@ alias test_in_serial='bundle && rails db:environment:set RAILS_ENV=test; rails d
 alias retest='rspec --only-failures'
 alias next_failure='rspec --next-failure'
 
-alias t='trans'
-
-alias ggr='googler'
-alias ggrks='googler'
-
 alias ctags_for_vim='ctags --recurse=yes -f $HOME/.vim/tags'
 
 alias start_postgres='pg_ctl -D /usr/local/var/postgres -l logfile start'

--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -127,11 +127,6 @@ alias test_in_serial='bundle && rails db:environment:set RAILS_ENV=test; rails d
 alias retest='rspec --only-failures'
 alias next_failure='rspec --next-failure'
 
-alias t='trans'
-
-alias ggr='googler'
-alias ggrks='googler'
-
 alias ctags_for_vim='ctags --recurse=yes -f $HOME/.vim/tags'
 
 alias start_postgres='pg_ctl -D /usr/local/var/postgres -l logfile start'


### PR DESCRIPTION
I've already removed those commands.

See also:
- https://github.com/machupicchubeta/dotfiles/commit/ab30ccfc96c7f68eb9412f80b7af91666f38be9d
- https://github.com/machupicchubeta/dotfiles/commit/9d41d9faa6a23ca5e77021f8dfbba7012b154496
