### PR TITLE
Make sure to upgrade `pip` command

### DIFF
--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -8,11 +8,8 @@ pyenv rehash
 
 eval "$(pyenv init -)"
 
-# pip
-pip install --upgrade pip
-
-# pip3
-pip3 install --upgrade pip setuptools wheel
+python3 -m pip install --upgrade pip
+pip3 install --upgrade setuptools wheel
 pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install --upgrade
 pip3 install cfn-lint
 pip3 install pynvim


### PR DESCRIPTION
Follow the warning message.
```
WARNING: You are using pip version 20.3.1; however, version 20.3.3 is available.
You should consider upgrading via the '/usr/local/opt/python@3.9/bin/python3.9 -m pip install --upgrade pip' command.
```
