### PR TITLE
R.I.P. Adobe Flash Player

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -248,7 +248,6 @@ brew install --cask vagrant
 brew install --cask virtualbox
 brew install --cask firefox
 brew install --cask firefox-developer-edition
-brew install --cask flash-npapi
 brew install --cask evernote
 brew install --cask slack
 brew install --cask skitch


### PR DESCRIPTION
Refs.
- https://www.adobe.com/products/flashplayer/end-of-life.html

> Since Adobe will no longer be supporting Flash Player after December 31, 2020 and Adobe will block Flash content from running in Flash Player beginning January 12, 2021, Adobe strongly recommends all users immediately uninstall Flash Player to help protect their systems.
