### PR TITLE
Remove `sshrc`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -111,7 +111,6 @@ brew install slackcat
 brew install lame
 brew install vault
 brew install yank
-brew install sshrc
 brew install v8
 brew install git-secrets
 brew install sslscan


### PR DESCRIPTION
It formulae had already been removed.
- https://github.com/Homebrew/homebrew-core/pull/50453

The repository missing now.
- https://github.com/Russell91/sshrc