### PR TITLE
Wipe out `rmtrash`

### DIFF
--- a/.bash/.aliases
+++ b/.bash/.aliases
@@ -27,8 +27,6 @@ alias rm='rm -i'
 alias cp='cp -i'
 alias mv='mv -i'
 
-alias del='rmtrash'
-
 alias pd='popd'
 
 alias mkdir='mkdir -p'

--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -19,8 +19,6 @@ alias rm='rm -i'
 alias cp='cp -i'
 alias mv='mv -i'
 
-alias del='rmtrash'
-
 alias pd='popd'
 
 alias mkdir='mkdir -p'

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -87,7 +87,6 @@ brew install screen
 brew install reattach-to-user-namespace
 # brew install gnupg
 brew install grc
-brew install rmtrash
 brew install tor
 brew install nkf
 brew install automake


### PR DESCRIPTION
It formulae had already been removed.
- https://github.com/Homebrew/homebrew-core/pull/65438

It seems no longer maintained.
- http://www.nightproductions.net/cli.htm