### PR TITLE
Get rid of deprecated `ccze`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -156,7 +156,6 @@ brew install terragrunt
 brew install kibana
 brew install protobuf
 brew install pv
-brew install ccze
 brew install git-secrets
 brew install testssl
 brew install kubernetes-cli


### PR DESCRIPTION
> Deprecated because it has an archived upstream repository!

```
$ brew info ccze

ccze: stable 0.2.1 (bottled)
Robust and modular log colorizer
https://packages.debian.org/wheezy/ccze
Deprecated because it has an archived upstream repository!
/usr/local/Cellar/ccze/0.2.1_1 (13 files, 138.3KB) *
  Poured from bottle on 2019-11-10 at 00:30:41
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/ccze.rb
License: GPL-2.0
==> Dependencies
Required: pcre ✔
==> Analytics
install: 64 (30 days), 207 (90 days), 944 (365 days)
install-on-request: 64 (30 days), 206 (90 days), 941 (365 days)
build-error: 0 (30 days)
```