### PR TITLE
Get rid of deprecated `json11`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -181,7 +181,6 @@ brew install elixir
 brew install elm
 brew install erlang
 brew install ghostscript
-brew install json11
 brew install duck
 brew install doctl
 brew install git-quick-stats


### PR DESCRIPTION
> Deprecated because it has an archived upstream repository!

```
$ brew info json11

json11: stable 1.0.0 (bottled)
Tiny JSON library for C++11
https://github.com/dropbox/json11
Deprecated because it has an archived upstream repository!
/usr/local/Cellar/json11/1.0.0 (7 files, 92.5KB) *
  Poured from bottle on 2019-11-10 at 00:34:37
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/json11.rb
License: MIT
==> Dependencies
Build: cmake ✔
==> Analytics
install: 3 (30 days), 12 (90 days), 78 (365 days)
install-on-request: 2 (30 days), 11 (90 days), 75 (365 days)
build-error: 0 (30 days)
```