### PR TITLE
Introduce Wireshark.app with Homebrew Cask, instead of the command-line utilities

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -115,7 +115,6 @@ brew install sshrc
 brew install v8
 brew install git-secrets
 brew install sslscan
-brew install wireshark
 brew install git-when-merged
 brew install fortune
 brew install cowsay
@@ -288,6 +287,7 @@ brew install --cask vlc
 brew install --cask chrome-remote-desktop-host
 brew install --cask vivaldi
 brew install --cask lacona
+brew install --cask wireshark
 brew install --cask wireshark-chmodbpf
 brew install --cask sketch
 brew install --cask flinto


### PR DESCRIPTION
```
$ brew info wireshark

Warning: Treating wireshark as a formula. For the cask, use homebrew/cask/wireshark
wireshark: stable 3.4.2 (bottled), HEAD
Graphical network analyzer and capture tool
https://www.wireshark.org
/usr/local/Cellar/wireshark/3.4.2 (1,185 files, 96.3MB) *
  Poured from bottle on 2020-12-26 at 11:58:17
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/wireshark.rb
License: GPL-2.0-or-later
==> Dependencies
Build: cmake ✔
Required: c-ares ✔, glib ✔, gnutls ✔, libgcrypt ✔, libmaxminddb ✔, libsmi ✔, libssh ✔, lua@5.1 ✔, nghttp2 ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
This formula only installs the command-line utilities by default.

Install Wireshark.app with Homebrew Cask:
  brew install --cask wireshark

If your list of available capture interfaces is empty
(default macOS behavior), install ChmodBPF:
  brew install --cask wireshark-chmodbpf
==> Analytics
install: 11,825 (30 days), 30,862 (90 days), 100,123 (365 days)
install-on-request: 11,156 (30 days), 26,034 (90 days), 73,030 (365 days)
build-error: 0 (30 days)
```

```
$ brew info --cask wireshark

wireshark: 3.4.2 (auto_updates)
https://www.wireshark.org/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/wireshark.rb
==> Name
Wireshark
==> Description
Network protocol analyzer
==> Artifacts
Add Wireshark to the system path.pkg (Pkg)
Install ChmodBPF.pkg (Pkg)
Wireshark.app (App)
/Applications/Wireshark.app/Contents/MacOS/editcap (Binary)
/Applications/Wireshark.app/Contents/MacOS/idl2wrs (Binary)
/Applications/Wireshark.app/Contents/MacOS/mergecap (Binary)
/Applications/Wireshark.app/Contents/MacOS/mmdbresolve (Binary)
/Applications/Wireshark.app/Contents/MacOS/randpkt (Binary)
/Applications/Wireshark.app/Contents/MacOS/reordercap (Binary)
/Applications/Wireshark.app/Contents/MacOS/sharkd (Binary)
/Applications/Wireshark.app/Contents/MacOS/text2pcap (Binary)
/Applications/Wireshark.app/Contents/MacOS/tshark (Binary)
/Applications/Wireshark.app/Contents/MacOS/extcap/androiddump (Binary)
/Applications/Wireshark.app/Contents/MacOS/extcap/ciscodump (Binary)
/Applications/Wireshark.app/Contents/MacOS/extcap/randpktdump (Binary)
/Applications/Wireshark.app/Contents/MacOS/extcap/sshdump (Binary)
/Applications/Wireshark.app/Contents/MacOS/extcap/udpdump (Binary)
/Applications/Wireshark.app/Contents/MacOS/rawshark (Binary)
/Applications/Wireshark.app/Contents/MacOS/capinfos (Binary)
/Applications/Wireshark.app/Contents/MacOS/captype (Binary)
/Applications/Wireshark.app/Contents/MacOS/dftest (Binary)
/Applications/Wireshark.app/Contents/MacOS/dumpcap (Binary)
==> Analytics
install: 2,244 (30 days), 7,952 (90 days), 37,972 (365 days)
```