### PR TITLE
Minimize path env for brew command

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -167,3 +167,5 @@ alias lzd='lazydocker'
 
 alias lg='lazygit'
 alias lzg='lazygit'
+
+alias brew='PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin brew'

--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -168,4 +168,5 @@ alias lzd='lazydocker'
 alias lg='lazygit'
 alias lzg='lazygit'
 
-alias brew='PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin brew'
+# alias brew='PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin brew'
+alias brew='env PATH=${PATH/$HOME\/\.pyenv\/shims:/} brew'


### PR DESCRIPTION
Warning was:
```
$ brew doctor

Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: "config" scripts exist outside your system or Homebrew directories.
`./configure` scripts often look for *-config scripts to determine if
software packages are installed, and which additional flags to use when
compiling and linking.

Having additional scripts in your path can confuse software installed via
Homebrew if the config script overrides a system or Homebrew-provided
script of the same name. We found the following "config" scripts:
  /Users/machupicchubeta/.pyenv/shims/python3.9-config
  /Users/machupicchubeta/.pyenv/shims/python-config
  /Users/machupicchubeta/.pyenv/shims/python3-config
```

Refs.
- https://qiita.com/takuya0301/items/695f42f6904e979f0152
- https://www.task-notes.com/entry/20141223/1419324649
- https://qiita.com/takc923/items/45386905f70fde9af0e7