### PR TITLE
Use `fzf` in Vim

### DIFF
--- a/.vim/rc/fzf.rc.vim
+++ b/.vim/rc/fzf.rc.vim
@@ -141,3 +141,4 @@ function! s:fzf_statusline()
 endfunction
 
 autocmd! User FzfStatusLine call <SID>fzf_statusline()
+set rtp+=/usr/local/opt/fzf


### PR DESCRIPTION
It references fzf comment.
```
$ brew info fzf

fzf: stable 0.25.0 (bottled), HEAD
Command-line fuzzy finder written in Go
https://github.com/junegunn/fzf
/usr/local/Cellar/fzf/0.25.0 (17 files, 3.7MB) *
  Poured from bottle on 2021-01-04 at 00:35:11
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/fzf.rb
License: MIT
==> Dependencies
Build: go ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
To install useful keybindings and fuzzy completion:
  /usr/local/opt/fzf/install

To use fzf in Vim, add the following line to your .vimrc:
  set rtp+=/usr/local/opt/fzf
==> Analytics
install: 26,210 (30 days), 109,429 (90 days), 259,144 (365 days)
install-on-request: 25,229 (30 days), 104,488 (90 days), 245,894 (365 days)
build-error: 0 (30 days)
```