### PR TITLE
Avoid an error to upgrade `vim` and `macvim`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -25,8 +25,10 @@ brew tap github/gh
 brew tap mongodb/brew
 brew tap clementtsang/bottom
 
-brew unlink macvim
 brew unlink vim
+brew upgrade macvim
+brew unlink macvim
+brew upgrade vim
 brew update
 brew upgrade --fetch-HEAD
 


### PR DESCRIPTION
They both contain vi* binaries, so unlink and upgrade coflicting `vim` and `macvim` explicitly.
The issue was not resolved in previous commits.
- https://github.com/machupicchubeta/dotfiles/commit/1bcb15ab6c4cc2f0d9ed54b2fcbed0f37138dc6a