### PR TITLE
Looks good without `wireshark-chmodbpf`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -317,7 +317,6 @@ brew install --cask chrome-remote-desktop-host
 brew install --cask vivaldi
 brew install --cask lacona
 brew install --cask wireshark
-brew install --cask wireshark-chmodbpf
 brew install --cask sketch
 brew install --cask flinto
 brew install --cask blisk


### PR DESCRIPTION
I did not have a chance to use `wireshark-chmodbpf` in my environment.
When I installed `wireshark` with "Homebrew Cask", I got an installation error due to conflicts, so I uninstalled it.

Error was:
> Error: Cask 'wireshark-chmodbpf' conflicts with 'wireshark'.