### PR TITLE
Use "GnuPG" command line tools, instead of GUI app

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -322,7 +322,6 @@ brew install --cask flinto
 brew install --cask blisk
 brew install --cask gitter
 brew install --cask flux
-brew install --cask gpg-suite
 brew install --cask fliqlo
 brew install --cask google-earth-pro
 brew install --cask zoomus

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -119,7 +119,7 @@ brew install ag
 brew install spark
 brew install tmux
 brew install reattach-to-user-namespace
-# brew install gnupg
+brew install gnupg
 brew install grc
 brew install tor
 brew install nkf
@@ -170,7 +170,6 @@ brew install sqlmap
 brew install rust
 brew install plenv
 brew install shyaml
-brew install gpg
 brew install shellcheck
 brew install ghq
 brew install flow


### PR DESCRIPTION
I will sign the git commits with GPG, soon.
I found that the command line tool is sufficient for that.

Refs.
- https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work
- https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/generating-a-new-gpg-key

Uninstall the GUI app, since it causes a `brew link` error in `gnupg`, if it is installed.
Error was:
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/gpg-agent
Target /usr/local/bin/gpg-agent
already exists. You may want to remove it:
  rm '/usr/local/bin/gpg-agent'

To force the link and overwrite all conflicting files:
  brew link --overwrite gnupg

To list all files that would be deleted:
  brew link --overwrite --dry-run gnupg

Possible conflicting files are:
/usr/local/bin/gpg-agent -> /usr/local/MacGPG2/bin/gpg-agent
```
