### PR TITLE
Enable compilers to find `libxml2`, `libxslt` and `libiconv`

### DIFF
--- a/.zsh/compiler_options.zsh
+++ b/.zsh/compiler_options.zsh
@@ -1,3 +1,4 @@
-export LDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/zlib/lib"
-export CPPFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/readline/include -I/usr/local/opt/zlib/include"
-export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig"
+export LDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/libxslt/lib -L/usr/local/opt/libiconv/lib"
+export CPPFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/readline/include -I/usr/local/opt/zlib/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/libxslt/include -I/usr/local/opt/libiconv/include"
+export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/libxml2/lib/pkgconfig:/usr/local/opt/libxslt/lib/pkgconfig"
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl"

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -14,7 +14,7 @@ export LESSOPEN='| /usr/local/bin/src-hilite-lesspipe.sh %s'
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 
-export PATH="/usr/local/opt/openssl/lib:/usr/local/opt/openssl/include:/usr/local/opt/openssl/bin:/usr/local/opt/libressl/bin:/usr/local/opt/curl/bin:/usr/local/opt/sqlite/bin:/usr/local/opt/nss/bin:$PYTHOPATH:$HOME/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/local/opt/go/libexec/bin"
+export PATH="/usr/local/opt/libxml2/bin:/usr/local/opt/libxslt/bin:/usr/local/opt/libiconv/bin:/usr/local/opt/openssl/lib:/usr/local/opt/openssl/include:/usr/local/opt/openssl/bin:/usr/local/opt/libressl/bin:/usr/local/opt/curl/bin:/usr/local/opt/sqlite/bin:/usr/local/opt/nss/bin:$PYTHOPATH:$HOME/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/local/opt/go/libexec/bin"
 export MANPATH="/usr/local/opt/coreutils/libexec/gnuman:/usr/local/man:$MANPATH"
 
 # Larger bash history (allow 2^10^2 entries; default is 500)

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -257,11 +257,8 @@ brew install libressl
 
 # for nokogiri
 brew install libxml2
-brew unlink libxml2
 brew install libxslt
-brew unlink libxslt
 brew install libiconv
-brew unlink libiconv
 
 # cask
 brew install --cask 1password


### PR DESCRIPTION
See also:
```
$ brew info libxml2

libxml2: stable 2.9.10 (bottled), HEAD [keg-only]
GNOME XML library
http://xmlsoft.org/
/usr/local/Cellar/libxml2/2.9.10_2 (280 files, 10.6MB)
  Poured from bottle on 2020-11-02 at 19:04:08
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libxml2.rb
License: MIT
==> Dependencies
Required: python@3.9 ✔, readline ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
libxml2 is keg-only, which means it was not symlinked into /usr/local,
because macOS already provides this software and installing another version in
parallel can cause all kinds of trouble.

If you need to have libxml2 first in your PATH run:
  echo 'export PATH="/usr/local/opt/libxml2/bin:$PATH"' >> ~/.zshrc

For compilers to find libxml2 you may need to set:
  export LDFLAGS="-L/usr/local/opt/libxml2/lib"
  export CPPFLAGS="-I/usr/local/opt/libxml2/include"

For pkg-config to find libxml2 you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/libxml2/lib/pkgconfig"

==> Analytics
install: 46,576 (30 days), 189,812 (90 days), 632,026 (365 days)
install-on-request: 30,154 (30 days), 115,239 (90 days), 326,602 (365 days)
build-error: 0 (30 days)
```

```
$ brew info libxslt

libxslt: stable 1.1.34 (bottled), HEAD [keg-only]
C XSLT library for GNOME
http://xmlsoft.org/XSLT/
/usr/local/Cellar/libxslt/1.1.34_2 (136 files, 3.0MB)
  Poured from bottle on 2021-01-03 at 17:21:29
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libxslt.rb
License: X11
==> Dependencies
Required: libgcrypt ✔, libxml2 ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
To allow the nokogiri gem to link against this libxslt run:
  gem install nokogiri -- --with-xslt-dir=/usr/local/opt/libxslt

libxslt is keg-only, which means it was not symlinked into /usr/local,
because macOS already provides this software and installing another version in
parallel can cause all kinds of trouble.

If you need to have libxslt first in your PATH run:
  echo 'export PATH="/usr/local/opt/libxslt/bin:$PATH"' >> ~/.zshrc

For compilers to find libxslt you may need to set:
  export LDFLAGS="-L/usr/local/opt/libxslt/lib"
  export CPPFLAGS="-I/usr/local/opt/libxslt/include"

For pkg-config to find libxslt you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/libxslt/lib/pkgconfig"

==> Analytics
install: 7,449 (30 days), 13,468 (90 days), 45,036 (365 days)
install-on-request: 6,921 (30 days), 12,528 (90 days), 40,279 (365 days)
build-error: 0 (30 days)
```

```
$ brew info libiconv

libiconv: stable 1.16 (bottled) [keg-only]
Conversion library
https://www.gnu.org/software/libiconv/
/usr/local/Cellar/libiconv/1.16 (30 files, 2.4MB)
  Poured from bottle on 2019-11-10 at 00:38:02
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libiconv.rb
License: GPL-3.0
==> Caveats
libiconv is keg-only, which means it was not symlinked into /usr/local,
because macOS already provides this software and installing another version in
parallel can cause all kinds of trouble.

If you need to have libiconv first in your PATH run:
  echo 'export PATH="/usr/local/opt/libiconv/bin:$PATH"' >> ~/.zshrc

For compilers to find libiconv you may need to set:
  export LDFLAGS="-L/usr/local/opt/libiconv/lib"
  export CPPFLAGS="-I/usr/local/opt/libiconv/include"

==> Analytics
install: 4,190 (30 days), 13,950 (90 days), 65,558 (365 days)
install-on-request: 2,685 (30 days), 9,071 (90 days), 42,729 (365 days)
build-error: 0 (30 days)
```