### PR TITLE
Use "OpenSSL" installed by "Homebrew" while compiling Ruby via `rbenv`

### DIFF
--- a/.zsh/compiler_options.zsh
+++ b/.zsh/compiler_options.zsh
@@ -1,3 +1,4 @@
 export LDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/libxslt/lib -L/usr/local/opt/libiconv/lib"
 export CPPFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/readline/include -I/usr/local/opt/zlib/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/libxslt/include -I/usr/local/opt/libiconv/include"
 export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/libxml2/lib/pkgconfig:/usr/local/opt/libxslt/lib/pkgconfig"
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl"


### PR DESCRIPTION
It is the environment variable suggested by `ruby-build`.
- https://github.com/rbenv/ruby-build/wiki#suggested-build-environment