### PR TITLE
Make sure to install latest "Go" version

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -139,7 +139,7 @@ brew install postgresql
 brew install parallel
 brew install nmap
 brew install go
-brew install goenv
+brew install goenv --HEAD
 brew install slackcat
 brew install lame
 brew install vault


### PR DESCRIPTION
The stable version of `goenv` can install "Go" upto `1.11.4`, while the beta version of `goenv` can install the latest "Go" `1.15.6`.
- https://github.com/syndbg/goenv/releases
- https://golang.org/dl/