### PR TITLE
Get rid of the unused PATH variable

### DIFF
--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -14,7 +14,7 @@ export LESSOPEN='| /usr/local/bin/src-hilite-lesspipe.sh %s'
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 
-export PATH="/usr/local/opt/libxml2/bin:/usr/local/opt/libxslt/bin:/usr/local/opt/libiconv/bin:/usr/local/opt/openssl/lib:/usr/local/opt/openssl/include:/usr/local/opt/openssl/bin:/usr/local/opt/libressl/bin:/usr/local/opt/curl/bin:/usr/local/opt/sqlite/bin:/usr/local/opt/nss/bin:$PYTHOPATH:$HOME/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/local/opt/go/libexec/bin"
+export PATH="/usr/local/opt/libxml2/bin:/usr/local/opt/libxslt/bin:/usr/local/opt/libiconv/bin:/usr/local/opt/openssl/lib:/usr/local/opt/openssl/include:/usr/local/opt/openssl/bin:/usr/local/opt/libressl/bin:/usr/local/opt/curl/bin:/usr/local/opt/sqlite/bin:/usr/local/opt/nss/bin:$HOME/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/local/opt/go/libexec/bin"
 export MANPATH="/usr/local/opt/coreutils/libexec/gnuman:/usr/local/man:$MANPATH"
 
 # Larger bash history (allow 2^10^2 entries; default is 500)
@@ -38,8 +38,6 @@ export DISABLE_SPRING=1
 export XDG_CONFIG_HOME=~/.config
 
 export ANDROID_SDK_ROOT='/usr/local/share/android-sdk'
-
-export PYTHONPATH=$(if which pyenv > /dev/null; then echo -n "$(pyenv root)/shims"; else '/usr/local/bin'; fi)
 
 export ENHANCD_FILTER=fzf
 export ENHANCD_DOT_ARG='~~'


### PR DESCRIPTION
Oops, it was a typo and was not used.
And `pyenv init` command automatically will inject shim executable path into `PATH` environment variables.
- https://github.com/pyenv/pyenv#how-it-works
> At a high level, pyenv intercepts Python commands using shim executables injected into your PATH, determines which Python version has been specified by your application, and passes your commands along to the correct Python installation.