### PR TITLE
Introduce `gcc`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -84,6 +84,7 @@ brew install sqlite
 brew install sl
 brew install zlib
 
+brew install gcc
 brew install cmake
 brew install tig
 brew install hub


### PR DESCRIPTION
```
$ brew info gcc

gcc: stable 10.2.0 (bottled), HEAD
GNU compiler collection
https://gcc.gnu.org/
/usr/local/Cellar/gcc/10.2.0_2 (1,455 files, 338.1MB) *
  Poured from bottle on 2021-01-14 at 22:58:09
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gcc.rb
License: GPL-3.0
==> Dependencies
Required: gmp ✔, isl ✔, libmpc ✔, mpfr ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 127,876 (30 days), 296,994 (90 days), 1,218,187 (365 days)
install-on-request: 62,472 (30 days), 139,909 (90 days), 575,331 (365 days)
build-error: 0 (30 days)
```