### PR TITLE
Don't forget to link vim after upgrade it

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -29,6 +29,7 @@ brew unlink vim
 brew upgrade macvim
 brew unlink macvim
 brew upgrade vim
+brw link vim
 brew update
 brew upgrade --fetch-HEAD
 


### PR DESCRIPTION
I had inadvertently forgotten about it and the link had been removed.