### PR TITLE
Stop to install `kubernetes-cli`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -190,7 +190,6 @@ brew install protobuf
 brew install pv
 brew install git-secrets
 brew install testssl
-brew install kubernetes-cli
 brew install kubernetes-helm
 brew install gradle
 brew install azure-cli


### PR DESCRIPTION
`kubernetes-cli` conflicts with `kubectl`, which `Docker.app` contains.
Therefore, I do not need to install it individually, now.

Error was:
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/kubectl
Target /usr/local/bin/kubectl
already exists. You may want to remove it:
  rm '/usr/local/bin/kubectl'

To force the link and overwrite all conflicting files:
  brew link --overwrite kubernetes-cli

To list all files that would be deleted:
  brew link --overwrite --dry-run kubernetes-cli

Possible conflicting files are:
/usr/local/bin/kubectl -> /Applications/Docker.app/Contents/Resources/bin/kubectl
```