### PR TITLE
Avoid Ruby installation fail

### DIFF
--- a/bin/setup_ruby.sh
+++ b/bin/setup_ruby.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
 
+sudo xcode-select -s /Library/Developer/CommandLineTools
+
 latest_ruby_version=$(rbenv install -l | grep -E '^(\d+\.\d+)\.\d+$' | tail -n 1)
 rbenv install --skip-existing $latest_ruby_version
 rbenv global $latest_ruby_version


### PR DESCRIPTION
It seems the developer toolchain is broken by macOS or Xcode upgrade installation.
Revise the developer toolchain before installing.

Refs.
- https://github.com/rbenv/ruby-build/issues/1505
- https://bugs.ruby-lang.org/issues/17486
- http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/94072
- https://public-inbox.org/ruby-core/redmine.journal-89651.20201230234616.6228@ruby-lang.org/