### PR TITLE
Correct `PYTHONPATH` to be `pyenv`, "Homebrew", pre-installed, in that order

### DIFF
--- a/.bash/.exports
+++ b/.bash/.exports
@@ -44,7 +44,7 @@ if which direnv > /dev/null; then eval "$(direnv hook bash)"; fi
 
 export ANDROID_SDK_ROOT='/usr/local/share/android-sdk'
 
-export PYTHONPATH=$(if which pyenv > /dev/null; then echo -n "$(pyenv root)/shims"; else '/usr/local/bin'; fi)
+export PYTHONPATH=$(if [ -d "$HOME/.pyenv/shims" ]; then echo "$HOME/.pyenv/shims"; elif [ -d '/usr/local/opt/python/libexec/bin' ]; then '/usr/local/opt/python/libexec/bin'; else '/usr/bin/python'; fi)
 
 export ENHANCD_FILTER=fzf
 export ENHANCD_DOT_ARG='~~'

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -39,6 +39,8 @@ export XDG_CONFIG_HOME=~/.config
 
 export ANDROID_SDK_ROOT='/usr/local/share/android-sdk'
 
+export PYTHONPATH=$(if [ -d "$HOME/.pyenv/shims" ]; then echo "$HOME/.pyenv/shims"; elif [ -d '/usr/local/opt/python/libexec/bin' ]; then '/usr/local/opt/python/libexec/bin'; else '/usr/bin/python'; fi)
+
 export ENHANCD_FILTER=fzf
 export ENHANCD_DOT_ARG='~~'
 


### PR DESCRIPTION
I was mistaken that I wasn't using `PYTHONPATH`, but realized that I was using it in `.vim/rc/init.rc.vim`.
- https://github.com/machupicchubeta/dotfiles/commit/f1f0f5c1d50f477f45304fd2839fa6e40ff51725

See also:
- https://github.com/machupicchubeta/dotfiles/blob/main/.vim/rc/init.rc.vim#L47
> let g:python3_host_prog = expand('$PYTHONPATH/python')