### PR TITLE
Add `ls` command alias for easy viewing by grouping

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -12,6 +12,8 @@ alias glsd='gls -l | grep "^d"'
 
 alias ls='lsd'
 alias lt='ls --tree'
+alias lss='ls -alh --group-dirs first'
+alias lk='ls -alh --group-dirs first'
 
 alias rrf='rm -rf'
 alias rr='rm -rfi'


### PR DESCRIPTION
Add two aliases with the same content, one that is easy to enter with a nearby key, and one that is easy to recall from the command name.
If one of them is easier to use, I think I'll keep it.