### PR TITLE
Use "Elastic Homebrew Tap" instead of "Homebrw Formulae"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -24,6 +24,7 @@ brew tap heroku/brew
 brew tap github/gh
 brew tap mongodb/brew
 brew tap clementtsang/bottom
+brew tap elastic/tap
 
 brew unlink vim
 brew upgrade macvim
@@ -185,7 +186,6 @@ brew install firebase-cli
 brew install logrotate
 brew install pre-commit
 brew install terragrunt
-brew install kibana
 brew install protobuf
 brew install pv
 brew install git-secrets
@@ -214,7 +214,6 @@ brew install ghostscript
 brew install duck
 brew install doctl
 brew install git-quick-stats
-brew install elasticsearch
 brew install peco
 brew install fzf
 brew install coffeescript
@@ -246,6 +245,8 @@ brew install procs
 brew install sd
 brew install lazydocker
 brew install lazygit
+brew install elasticsearch-full
+brew install kibana-full
 
 # for ruby
 brew install openssl


### PR DESCRIPTION
Refs.
- https://formulae.brew.sh/formula/elasticsearch
> Deprecated because it is switching to an incompatible license!

- https://github.com/elastic/homebrew-tap
- https://www.elastic.co/guide/en/elasticsearch/reference/7.x/brew.html

```
$ brew doctor

Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Some installed formulae are deprecated or disabled.
You should find replacements for the following formulae:
  elasticsearch
  kibana
```

```
$ brew info elasticsearch

elasticsearch: stable 7.10.2 (bottled)
Distributed search & analytics engine
https://www.elastic.co/products/elasticsearch
Deprecated because it is switching to an incompatible license!
/usr/local/Cellar/elasticsearch/7.10.2 (156 files, 113.5MB) *
  Poured from bottle on 2021-01-18 at 01:32:36
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/elasticsearch.rb
License: Apache-2.0
==> Dependencies
Build: gradle ✔
Required: openjdk ✔
==> Caveats
Data:    /usr/local/var/lib/elasticsearch/
Logs:    /usr/local/var/log/elasticsearch/elasticsearch_machupicchubeta.log
Plugins: /usr/local/var/elasticsearch/plugins/
Config:  /usr/local/etc/elasticsearch/

To have launchd start elasticsearch now and restart at login:
  brew services start elasticsearch
Or, if you don't want/need a background service you can just run:
  elasticsearch
==> Analytics
install: 4,114 (30 days), 16,972 (90 days), 74,568 (365 days)
install-on-request: 4,104 (30 days), 16,612 (90 days), 71,692 (365 days)
build-error: 0 (30 days)
```

- https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/elasticsearch.rb#L16-L18
- https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/kibana.rb#L18-L20

```
# elasticsearch will be relicensed before v7.11.
# https://www.elastic.co/blog/licensing-change
deprecate! date: "2021-01-14", because: "is switching to an incompatible license"
```