### PR TITLE
Install "FontForge.app" instead of the command line utilities

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -127,7 +127,6 @@ brew install grc
 brew install tor
 brew install nkf
 brew install automake
-brew install fontforge
 brew install p7zip
 brew install pick
 brew install docutils
@@ -348,6 +347,7 @@ brew install --cask brave-browser
 brew install --cask raindropio
 brew install --cask postman
 brew install --cask messenger
+brew install --cask fontforge
 
 # fonts
 brew install --cask font-fira-code


### PR DESCRIPTION
```
$ brew info fontforge

Warning: Treating fontforge as a formula. For the cask, use homebrew/cask/fontforge
fontforge: stable 20201107 (bottled)
Command-line outline and bitmap font editor/converter
https://fontforge.github.io
/usr/local/Cellar/fontforge/20201107 (420 files, 16.2MB) *
  Poured from bottle on 2021-01-17 at 23:19:43
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/fontforge.rb
==> Dependencies
Build: cmake ✔, ninja ✘, pkg-config ✔
Required: cairo ✔, fontconfig ✔, freetype ✔, gettext ✔, giflib ✔, glib ✔, jpeg ✔, libpng ✔, libspiro ✔, libtiff ✔, libtool ✔, libuninameslist ✔, pango ✔, python@3.9 ✔, readline ✔
==> Caveats
This formula only installs the command line utilities.

FontForge.app can be downloaded directly from the website:
  https://fontforge.github.io

Alternatively, install with Homebrew Cask:
  brew install --cask fontforge
==> Analytics
install: 3,210 (30 days), 16,576 (90 days), 42,872 (365 days)
install-on-request: 2,572 (30 days), 12,439 (90 days), 30,154 (365 days)
build-error: 0 (30 days)
```

```
$ brew info --cask fontforge

fontforge: 2020-11-07,21ad4a1
https://fontforge.github.io/en-US/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/fontforge.rb
==> Name
FontForge
==> Description
Font editor and converter for outline and bitmap fonts
==> Artifacts
FontForge.app (App)
==> Analytics
install: 242 (30 days), 832 (90 days), 3,550 (365 days)
```