### PR TITLE
Follow the renaming of `zoomus` to `zoom`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -321,7 +321,7 @@ brew install --cask gitter
 brew install --cask flux
 brew install --cask fliqlo
 brew install --cask google-earth-pro
-brew install --cask zoomus
+brew install --cask zoom
 brew install --cask spotify
 brew install --cask chromedriver
 brew install --cask microsoft-remote-desktop-beta


### PR DESCRIPTION
```
$ brew info --cask zoomus

zoomus: 5.4.58903.1122,alias
https://www.zoom.us/
/usr/local/Caskroom/zoomus/5.4.58903.1122,alias (23MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/zoomus.rb
==> Name
Zoom.us makeshift alias
==> Description
Temporary makeshift alias for the video communication tool Zoom
==> Artifacts
==> Caveats
RENAME WARNING

Due to prevalent user confusion, the zoomus cask (this one) will be renamed to zoom.
In the meantime, zoomus will install zoom for you as a dependency, but you should update your scripts.

We’re aware this solution is subpar. If you’d like to help us improve it,
we accept PRs and need the equivalent of formula_renames.json for casks: https://docs.brew.sh/Rename-A-Formula

To migrate now, do:
  brew uninstall zoomus
  brew install zoom

==> Analytics
install: 2,070 (30 days), 12,971 (90 days), 58,160 (365 days)
```

```
$ brew info --cask zoom

zoom: 5.4.59931.0110
https://www.zoom.us/
/usr/local/Caskroom/zoom/5.4.59931.0110 (23.3MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/zoom.rb
==> Name
Zoom.us
==> Description
Video communication and virtual meeting platform
==> Artifacts
Zoom.pkg (Pkg)
==> Analytics
install: 9,150 (30 days), 29,928 (90 days), 48,242 (365 days)
```