### PR TITLE
Ensure to grep with perl regular expressions

### DIFF
--- a/bin/setup_go.sh
+++ b/bin/setup_go.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-latest_go_version=$(goenv install -l | grep -E '^\s+(\d+\.\d+)\.\d+$' | tail -n 1 | sed -e 's/^[ ]*//g')
+latest_go_version=$(goenv install -l | grep --perl-regexp '^\s+(\d+\.\d+)\.\d+$' | tail -n 1 | sed -e 's/^[ ]*//g')
 goenv install --skip-existing $latest_go_version
 goenv global $latest_go_version
 goenv rehash

--- a/bin/setup_nodejs.sh
+++ b/bin/setup_nodejs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-latest_nodejs_version=$(nodenv install -l | grep -E '^(\d+\.\d+)\.\d+$' | tail -n 1)
+latest_nodejs_version=$(nodenv install -l | grep --perl-regexp '^(\d+\.\d+)\.\d+$' | tail -n 1)
 nodenv install --skip-existing $latest_nodejs_version
 nodenv global $latest_nodejs_version
 nodenv rehash

--- a/bin/setup_perl.sh
+++ b/bin/setup_perl.sh
@@ -12,7 +12,7 @@ else
   cd $PERL_BUILD_PATH && git checkout master && git pull --rebase --prune
 fi
 
-latest_perl5_version=$(plenv install -l | grep -E '^\s+5\.\d+\.\d+$' | awk -F'[.]' '{ if ($2 %2 == 0) print $0 }' | head -n 1 | sed -e 's/^[ ]*//g')
+latest_perl5_version=$(plenv install -l | grep --perl-regexp '^\s+5\.\d+\.\d+$' | awk -F'[.]' '{ if ($2 %2 == 0) print $0 }' | head -n 1 | sed -e 's/^[ ]*//g')
 if ! [[ $(plenv versions | grep $latest_perl5_version) ]]; then
   plenv install $latest_perl5_version
 fi

--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-latest_python3_version=$(pyenv install -l | grep -E '^\s+3\.\d+\.\d+$' | tail -n 1 | sed -e 's/^[ ]*//g')
+latest_python3_version=$(pyenv install -l | grep --perl-regexp '^\s+3\.\d+\.\d+$' | tail -n 1 | sed -e 's/^[ ]*//g')
 pyenv install --skip-existing $latest_python3_version
 pyenv global $latest_python3_version
 pyenv rehash

--- a/bin/setup_ruby.sh
+++ b/bin/setup_ruby.sh
@@ -3,7 +3,7 @@ set -eu
 
 sudo xcode-select -s /Library/Developer/CommandLineTools
 
-latest_ruby_version=$(rbenv install -l | grep -E '^(\d+\.\d+)\.\d+$' | tail -n 1)
+latest_ruby_version=$(rbenv install -l | grep --perl-regexp '^(\d+\.\d+)\.\d+$' | tail -n 1)
 rbenv install --skip-existing $latest_ruby_version
 rbenv global $latest_ruby_version
 rbenv rehash
@@ -15,5 +15,5 @@ gem update --system
 gem update
 gem cleanup
 
-latest_solargraph_core_version=$(solargraph available-cores | grep -E '^(\d+\.\d+)\.\d+$' | head -n 1)
+latest_solargraph_core_version=$(solargraph available-cores | grep --perl-regexp '^(\d+\.\d+)\.\d+$' | head -n 1)
 solargraph download-core $latest_solargraph_core_version


### PR DESCRIPTION
In "GNU grep", `-E` (`--extended-regexp `) option cannot recognize and/or use perl regular expressions.

See also:
```
$ grep --help

Usage: grep [OPTION]... PATTERNS [FILE]...
Search for PATTERNS in each FILE.
Example: grep -i 'hello world' menu.h main.c
PATTERNS can contain multiple patterns separated by newlines.

Pattern selection and interpretation:
  -E, --extended-regexp     PATTERNS are extended regular expressions
  -F, --fixed-strings       PATTERNS are strings
  -G, --basic-regexp        PATTERNS are basic regular expressions
  -P, --perl-regexp         PATTERNS are Perl regular expressions
  -e, --regexp=PATTERNS     use PATTERNS for matching
  -f, --file=FILE           take PATTERNS from FILE
  -i, --ignore-case         ignore case distinctions in patterns and data
      --no-ignore-case      do not ignore case distinctions (default)
  -w, --word-regexp         match only whole words
  -x, --line-regexp         match only whole lines
  -z, --null-data           a data line ends in 0 byte, not newline

Miscellaneous:
  -s, --no-messages         suppress error messages
  -v, --invert-match        select non-matching lines
  -V, --version             display version information and exit
      --help                display this help text and exit

Output control:
  -m, --max-count=NUM       stop after NUM selected lines
  -b, --byte-offset         print the byte offset with output lines
  -n, --line-number         print line number with output lines
      --line-buffered       flush output on every line
  -H, --with-filename       print file name with output lines
  -h, --no-filename         suppress the file name prefix on output
      --label=LABEL         use LABEL as the standard input file name prefix
  -o, --only-matching       show only nonempty parts of lines that match
  -q, --quiet, --silent     suppress all normal output
      --binary-files=TYPE   assume that binary files are TYPE;
                            TYPE is 'binary', 'text', or 'without-match'
  -a, --text                equivalent to --binary-files=text
  -I                        equivalent to --binary-files=without-match
  -d, --directories=ACTION  how to handle directories;
                            ACTION is 'read', 'recurse', or 'skip'
  -D, --devices=ACTION      how to handle devices, FIFOs and sockets;
                            ACTION is 'read' or 'skip'
  -r, --recursive           like --directories=recurse
  -R, --dereference-recursive  likewise, but follow all symlinks
      --include=GLOB        search only files that match GLOB (a file pattern)
      --exclude=GLOB        skip files that match GLOB
      --exclude-from=FILE   skip files that match any file pattern from FILE
      --exclude-dir=GLOB    skip directories that match GLOB
  -L, --files-without-match  print only names of FILEs with no selected lines
  -l, --files-with-matches  print only names of FILEs with selected lines
  -c, --count               print only a count of selected lines per FILE
  -T, --initial-tab         make tabs line up (if needed)
  -Z, --null                print 0 byte after FILE name

Context control:
  -B, --before-context=NUM  print NUM lines of leading context
  -A, --after-context=NUM   print NUM lines of trailing context
  -C, --context=NUM         print NUM lines of output context
  -NUM                      same as --context=NUM
      --color[=WHEN],
      --colour[=WHEN]       use markers to highlight the matching strings;
                            WHEN is 'always', 'never', or 'auto'
  -U, --binary              do not strip CR characters at EOL (MSDOS/Windows)

When FILE is '-', read standard input.  With no FILE, read '.' if
recursive, '-' otherwise.  With fewer than two FILEs, assume -h.
Exit status is 0 if any line is selected, 1 otherwise;
if any error occurs and -q is not given, the exit status is 2.

Report bugs to: bug-grep@gnu.org
GNU grep home page: <https://www.gnu.org/software/grep/>
General help using GNU software: <https://www.gnu.org/gethelp/>
```

```
$ brew info grep

grep: stable 3.6 (bottled)
GNU grep, egrep and fgrep
https://www.gnu.org/software/grep/
/usr/local/Cellar/grep/3.6 (21 files, 964.6KB) *
  Poured from bottle on 2021-01-17 at 22:15:43
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/grep.rb
License: GPL-3.0-or-later
==> Dependencies
Build: pkg-config ✔
Required: pcre ✔
==> Caveats
All commands have been installed with the prefix "g".
If you need to use these commands with their normal names, you
can add a "gnubin" directory to your PATH from your bashrc like:
  PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"
==> Analytics
install: 6,056 (30 days), 27,021 (90 days), 82,438 (365 days)
install-on-request: 5,698 (30 days), 25,087 (90 days), 75,883 (365 days)
build-error: 0 (30 days)
```