### PR TITLE
Ignore `xargs` command if input is empty

### DIFF
--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -10,7 +10,7 @@ eval "$(pyenv init -)"
 
 python3 -m pip install --upgrade pip
 pip3 install --upgrade setuptools wheel
-pip3 list --outdated | awk 'NR>2{print $1}' | xargs pip3 install --upgrade
+pip3 list --outdated | awk 'NR>2{print $1}' | xargs --no-run-if-empty pip3 install --upgrade
 pip3 install cfn-lint
 pip3 install pynvim
 /usr/local/bin/pip3 install pynvim


### PR DESCRIPTION
It prevent the error, as follows.
```
ERROR: You must give at least one requirement to install (see "pip help install")
```