### PR TITLE
Introduce `gdbm`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -85,6 +85,7 @@ brew install zlib
 
 brew install gcc
 brew install cmake
+brew install gdbm
 brew install tig
 brew install hub
 brew install git-lfs


### PR DESCRIPTION
```
$ brew info gdbm

gdbm: stable 1.18.1 (bottled)
GNU database manager
https://www.gnu.org/software/gdbm/
/usr/local/Cellar/gdbm/1.18.1_1 (25 files, 787.2KB) *
  Poured from bottle on 2021-02-07 at 13:24:58
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gdbm.rb
License: GPL-3.0
==> Analytics
install: 316,556 (30 days), 985,921 (90 days), 3,698,509 (365 days)
install-on-request: 3,413 (30 days), 12,682 (90 days), 46,177 (365 days)
build-error: 0 (30 days)
```