### PR TITLE
Make sure always to install "Command Line Tools" at every run setup script

### DIFF
--- a/bin/setup_command_line_tools.sh
+++ b/bin/setup_command_line_tools.sh
@@ -2,17 +2,23 @@
 set -eu
 
 COMMAND_LINE_TOOLS_PATH='/Library/Developer/CommandLineTools'
-if [[ $(xcode-select --print-path) != "$COMMAND_LINE_TOOLS_PATH" ]]; then
-  sudo rm -rf "$COMMAND_LINE_TOOLS_PATH"
-  xcode-select --install
-  sudo xcode-select -s "$COMMAND_LINE_TOOLS_PATH"
-fi
-
-# If the "Command Line Tools" installed via Xcode that is necessary to agree with its license to using it.
-# But, in this case, it is using "Command Line Tools" installed via command-line, so that is unnecessary to `xcodebuild --license` command.
-# If run the command that occurs an error as the following.
-# Error was:
-# > xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
-# sudo xcodebuild -license
-
+sudo rm -rf "$COMMAND_LINE_TOOLS_PATH"
+xcode-select --install > /dev/null 2>&1
+sleep 1
+osascript > /dev/null << EOD
+tell application "System Events"
+  tell process "Install Command Line Developer Tools"
+    click button "Install" of first window
+    click button "Agree" of window "License Agreement"
+    repeat
+      delay 0.5
+      if name of first button of first window contains "Done" then
+        exit repeat
+      end if
+    end repeat
+    click button "Done" of first window
+  end tell
+end tell
+EOD
+sudo xcode-select --switch "$COMMAND_LINE_TOOLS_PATH"
 xcode-select --print-path


### PR DESCRIPTION
When running `xcode-select --install` command, it may determine that the installation is done even if the SDK is missing.
In particular, after upgrading macOS, the SDK and other command directories often disappear, and even in that state, the installation was determined as completed.
Therefore, I decided to remove its whole directory and reinstall it every time I run the setup script.
