### PR TITLE
Remove "Android" development tools

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -32,9 +32,7 @@ brew update
 brew upgrade --fetch-HEAD
 
 # sleuthkit
-brew install --cask adoptopenjdk
 brew install --cask java
-brew install --cask adoptopenjdk8
 brew install sleuthkit
 
 # GNU command line tools
@@ -326,8 +324,6 @@ brew install --cask microsoft-remote-desktop-beta
 brew install --cask dotnet
 brew install --cask visual-studio
 brew install --cask visual-studio-code
-brew install --cask android-sdk
-brew install --cask android-studio
 brew install --cask dynamodb-local
 brew install --cask phantomjs
 brew install --cask discord

--- a/bin/setup_java.sh
+++ b/bin/setup_java.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eu
 
-jenv add $(/usr/libexec/java_home -v 1.8)
 jenv add $(/usr/libexec/java_home)
 
 eval "$(jenv init -)"


### PR DESCRIPTION
I think I didn't use it once.
I installed it because I was interested in it, but then I lost interest.

Since `adoptopenjdk` was installed for "Android" development, I will remove it at this time.

```
$ brew info --cask android-sdk

android-sdk: 4333796
https://developer.android.com/studio/releases/sdk-tools
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/android-sdk.rb
==> Name
android-sdk
==> Description
None
==> Artifacts
/usr/local/Caskroom/android-sdk/4333796/tools/android (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/emulator (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/emulator-check (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/mksdcard (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/monitor (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/apkanalyzer (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/archquery (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/avdmanager (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/jobb (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/lint (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/monkeyrunner (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/screenshot2 (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/sdkmanager (Binary)
/usr/local/Caskroom/android-sdk/4333796/tools/bin/uiautomatorviewer (Binary)
==> Caveats
android-sdk requires Java 8. You can install it with:
  brew install --cask homebrew/cask-versions/adoptopenjdk8

android-sdk has been officially discontinued upstream.
It may stop working correctly (or at all) in recent versions of macOS.

==> Analytics
install: 3,738 (30 days), 10,298 (90 days), 49,068 (365 days)
```