### PR TITLE
No longer `microsoft-remote-desktop-beta` exists in "Homebrew Cask" and/or "Homebrew Cask versions"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -317,7 +317,6 @@ brew install --cask google-earth-pro
 brew install --cask zoom
 brew install --cask spotify
 brew install --cask chromedriver
-brew install --cask microsoft-remote-desktop-beta
 brew install --cask dotnet
 brew install --cask visual-studio
 brew install --cask visual-studio-code


### PR DESCRIPTION
No longer `microsoft-remote-desktop-beta` exists in "Homebrew Cask" and/or "Homebrew Cask versions"

See also:
- https://github.com/Homebrew/homebrew-cask-versions/pull/8947
- https://github.com/Homebrew/homebrew-cask-versions/commit/d46112561145ed6a29a355f16c7ec6ed3404c277
- https://github.com/Homebrew/homebrew-cask/issues/80779

If I want to use it, it seems be able to install it from the App Store.
```
$ mas info 1295203466

Microsoft Remote Desktop 10.5.1 [0.0]
By: Microsoft Corporation
Released: Jan 20, 2021
Minimum OS: 10.13
Size: 19.7 MB
From: https://apps.apple.com/us/app/microsoft-remote-desktop/id1295203466?mt=12&uo=4
```
