### PR TITLE
Introduce "drawio-desktop" :triangular_ruler: :pencil:

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -338,6 +338,7 @@ brew install --cask zoom-outlook-plugin
 brew install --cask box-sync
 brew install --cask box-drive
 brew install --cask box-notes
+brew install --cask drawio
 
 brew install --cask font-fira-code
 brew install --cask font-firacode-nerd-font


### PR DESCRIPTION
https://github.com/jgraph/drawio-desktop

> drawio-desktop is a diagrams.net desktop app based on Electron.  draw.io is the old name for diagrams.net, we just don't want the hassle of changing all the binary's names.

```
$ brew info --cask drawio

drawio: 14.4.3
https://www.draw.io/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/drawio.rb
==> Name
draw.io Desktop
==> Description
Draw.io is free online diagram software
==> Artifacts
draw.io.app (App)
==> Analytics
install: 1,315 (30 days), 3,513 (90 days), 13,668 (365 days)
```