### PR TITLE
Unnecessary to install the 'microsoft-outlook' Cask separately

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -333,7 +333,6 @@ brew install --cask postman
 brew install --cask messenger
 brew install --cask fontforge
 brew install --cask microsoft-office
-brew install --cask microsoft-outlook
 brew install --cask zoom-outlook-plugin
 brew install --cask box-sync
 brew install --cask box-drive


### PR DESCRIPTION
If I install 'microsoft-office' Cask, "Microsoft Outlook" app will also be installed.
I got a conflict error because I had already installed the 'microsoft-office' Cask.

Error was:
```
Error: Cask 'microsoft-outlook' conflicts with 'microsoft-office'.
```
