### PR TITLE
No longer supported 'zoom-outlook-plugin' Cask on macOS newer than "Mojave"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -333,7 +333,6 @@ brew install --cask postman
 brew install --cask messenger
 brew install --cask fontforge
 brew install --cask microsoft-office
-brew install --cask zoom-outlook-plugin
 brew install --cask box-sync
 brew install --cask box-drive
 brew install --cask box-notes


### PR DESCRIPTION
Error was:
```
Error: This cask does not run on macOS versions newer than Mojave.
```
