### PR TITLE
No longer recommended to install "Box Sync"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -333,7 +333,6 @@ brew install --cask postman
 brew install --cask messenger
 brew install --cask fontforge
 brew install --cask microsoft-office
-brew install --cask box-sync
 brew install --cask box-drive
 brew install --cask box-notes
 brew install --cask drawio


### PR DESCRIPTION
When we install "Box Drive" with "Homebrew", "Box Sync" has been set to conflict.
"Box" support page recommends using "Box Drive", and announces that "Box Sync" will be uninstalled when "Box Drive" is going to install.

See also:
- https://support.box.com/hc/en-us/articles/360043697354-Switching-from-Box-Sync-to-Box-Drive
- https://support.box.com/hc/en-us/articles/360044196753-Uninstalling-Box-Sync-Using-Box-Drive
- https://formulae.brew.sh/cask/box-drive
- https://github.com/Homebrew/homebrew-cask/blob/master/Casks/box-drive.rb
