### PR TITLE
Install `rust` with `rustup-init` even if `rust` is already installed via "Homebrew"

### DIFF
--- a/bin/setup_rust.sh
+++ b/bin/setup_rust.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu
 
-# if ! which rustc > /dev/null; then rustup-init -y --no-modify-path --default-host x86_64-apple-darwin --default-toolchain stable --profile default; fi
-if ! which rustc > /dev/null; then rustup-init -y --no-update-default-toolchain --no-modify-path; fi
+# if [[ ! -d "$HOME/.cargo/bin" ]]; then RUSTUP_INIT_SKIP_PATH_CHECK=yes rustup-init -y --no-modify-path --default-host x86_64-apple-darwin --default-toolchain stable --profile default; fi
+if [[ ! -d "$HOME/.cargo/bin" ]]; then RUSTUP_INIT_SKIP_PATH_CHECK=yes rustup-init -y --no-update-default-toolchain --no-modify-path; fi
 rustup update
 
 if [[ ! -f /usr/local/etc/bash_completion.d/rustup.bash-completion ]]; then rustup completions bash > /usr/local/etc/bash_completion.d/rustup.bash-completion; fi


### PR DESCRIPTION
Even if I have already installed `rust` via "Homebrew", I want to use `rustup-init` to install `rust` in "$HOME/.cargo/bin".
Since `rustc` exists, I can use the existence of the "$HOME/.cargo/bin" directory to determine whether installation is required or not,
and it seems to set the "RUSTUP_INIT_SKIP_PATH_CHECK" environment variable to "yes" to install it regardless of whether `rust` exists or not.

WARNING was:
```
$ bin/setup_rust.sh

warning: it looks like you have an existing installation of Rust at:
warning: /usr/local/bin
warning: rustup should not be installed alongside Rust. Please uninstall your existing Rust first.
warning: Otherwise you may have confusion unless you are careful with your PATH
warning: If you are sure that you want both rustup and your already installed Rust
warning: then please reply `y' or `yes' or set RUSTUP_INIT_SKIP_PATH_CHECK to yes
warning: or pass `-y' to ignore all ignorable checks.
error: cannot install while Rust is installed
warning: continuing (because the -y flag is set and the error is ignorable)
info: profile set to 'default'
info: default host triple is x86_64-apple-darwin
info: updating existing rustup installation - leaving toolchains alone

Rust is installed now. Great!

To get started you need Cargo's bin directory ($HOME/.cargo/bin) in your PATH
environment variable.

To configure your current shell, run:
source $HOME/.cargo/env
info: no updatable toolchains installed
info: cleaning up downloads & tmp directories
```
