### PR TITLE
Introduce "GraphicsMagick"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -240,6 +240,7 @@ brew install openjdk
 brew install sleuthkit
 brew install robotsandpencils/made/xcodes
 brew install libressl
+brew install graphicsmagick
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
http://www.graphicsmagick.org

```
$ brew info graphicsmagick

graphicsmagick: stable 1.3.36 (bottled), HEAD
Image processing tools collection
http://www.graphicsmagick.org/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/graphicsmagick.rb
==> Dependencies
Build: pkg-config ✔
Required: freetype ✔, jasper ✘, jpeg ✔, libpng ✔, libtiff ✔, libtool ✔, little-cms2 ✔, webp ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 10,024 (30 days), 34,326 (90 days), 110,758 (365 days)
install-on-request: 5,712 (30 days), 19,316 (90 days), 60,261 (365 days)
build-error: 0 (30 days)
```
