### PR TITLE
Introduce "unox", "fswatch", "unison"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -22,6 +22,7 @@ brew tap github/gh
 brew tap mongodb/brew
 brew tap clementtsang/bottom
 brew tap elastic/tap
+brew tap eugenmayer/dockersync
 
 brew unlink vim
 brew upgrade macvim
@@ -241,6 +242,9 @@ brew install sleuthkit
 brew install robotsandpencils/made/xcodes
 brew install libressl
 brew install graphicsmagick
+brew install unox
+brew install fswatch
+brew install unison
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
Install some tools to combine with "docker-sync".

- https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html#advanced-optional
- https://github.com/hnsl/unox
- https://github.com/emcrisostomo/fswatch
- https://www.cis.upenn.edu/~bcpierce/unison/

```
$ brew info unox

eugenmayer/dockersync/unox: stable 0.2.0, HEAD
A layer for unison-fsmonitor arround either macfsevents or watchdog for usage with unison
https://github.com/hnsl/unox
Not installed
From: https://github.com/eugenmayer/homebrew-dockersync/blob/HEAD/Formula/unox.rb
==> Dependencies
Required: python@3 ✔
==> Options
--HEAD
	Install HEAD version
```

```
$ brew info fswatch

fswatch: stable 1.15.0 (bottled)
Monitor a directory for changes and run a shell command
https://github.com/emcrisostomo/fswatch
Not installed
From:
https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/fswatch.rb
License: GPL-3.0
==> Analytics
install: 3,432 (30 days), 8,968 (90 days), 41,611 (365 days)
install-on-request: 2,101 (30 days), 5,791 (90 days), 26,866 (365 days)
build-error: 0 (30 days)
```

```
$ brew info unison

Warning: Treating unison as a formula. For the cask, use homebrew/cask/unison
unison: stable 2.51.3 (bottled), HEAD
File synchronization tool for OSX
https://www.cis.upenn.edu/~bcpierce/unison/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/unison.rb
License: GPL-3.0-or-later
==> Dependencies
Build: ocaml ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 1,514 (30 days), 4,190 (90 days), 17,295 (365 days)
install-on-request: 1,506 (30 days), 4,173 (90 days), 17,019 (365 days)
build-error: 0 (30 days)
```
