### PR TITLE
Introduce "shared-mime-info"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -247,6 +247,7 @@ brew install unox
 brew install fswatch
 brew install unison
 brew install nodenv-package-json-engine
+brew install shared-mime-info
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
I had to install "feedesktop.org.xml" separately, which is used by the "mimemagic" gem.
It seems that "feedesktop.org.xml" was unbundled from the "mimemagic" gem due to licensing issues.

Refs.
- https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md#037-2021-03-25
- https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md#042
- https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md#039-2021-03-25
- https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md#038-2021-03-25
- https://github.com/mimemagicrb/mimemagic#dependencies

> You will require a copy of the Freedesktop.org shared-mime-info database to be available. If you're on Linux, it's probably available via your package manager, and will probably be in the location it's being looked for when the gem is installed.

See also:
- https://github.com/rails/rails/issues/41750
- https://github.com/rails/rails/issues/41757
- https://formulae.brew.sh/formula/shared-mime-info
- https://github.com/Homebrew/homebrew-core/blob/master/Formula/shared-mime-info.rb
- https://wiki.freedesktop.org/www/Software/shared-mime-info/
