### PR TITLE
Introduce "graphviz"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -248,6 +248,7 @@ brew install fswatch
 brew install unison
 brew install nodenv-package-json-engine
 brew install shared-mime-info
+brew install graphviz
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info graphviz

graphviz: stable 2.47.0 (bottled), HEAD
Graph visualization software from AT&T and Bell Labs
https://www.graphviz.org/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/graphviz.rb
License: EPL-1.0
==> Dependencies
Build: autoconf ✔, automake ✔, bison ✘, pkg-config ✔
Required: gd ✘, gts ✘, libpng ✔, librsvg ✘, libtool ✔, pango ✘
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 82,761 (30 days), 215,467 (90 days), 641,708 (365 days)
install-on-request: 69,487 (30 days), 178,222 (90 days), 516,946 (365 days)
build-error: 0 (30 days)
```
