### PR TITLE
Stop to aliasing `hub` as `git`

### DIFF
--- a/.bash/hooks.sh
+++ b/.bash/hooks.sh
@@ -10,8 +10,6 @@ test -e '/usr/local/etc/bash_completion' && source '/usr/local/etc/bash_completi
 test -e '/usr/local/opt/fzf/shell/completion.bash' && source '/usr/local/opt/fzf/shell/completion.bash'
 test -e '/usr/local/opt/fzf/shell/key-bindings.bash' && source '/usr/local/opt/fzf/shell/key-bindings.bash'
 
-eval "$(hub alias -s)"
-
 eval $(gdircolors ~/Repositories/github.com/seebi/dircolors-solarized)
 
 ssh-add -A &> /dev/null

--- a/.zsh/hooks.zsh
+++ b/.zsh/hooks.zsh
@@ -5,7 +5,6 @@ if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
 if which goenv > /dev/null; then eval "$(goenv init -)"; fi
 if which jenv > /dev/null; then eval "$(jenv init -)"; fi
 if which direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
-if which hub > /dev/null; then eval "$(hub alias -s)"; fi
 if which zoxide > /dev/null; then eval "$(zoxide init zsh)"; fi
 
 if [ -r '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh' ]; then source '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh'; fi


### PR DESCRIPTION
I don't use the `hub` command as much as I used to.
It's no longer beneficial to me to alias it to the `git` command.

Refs.
- https://github.com/github/hub#aliasing