### PR TITLE
Enable text selection in "QuickLook"

### DIFF
--- a/bin/setup_qlmarkdown.sh
+++ b/bin/setup_qlmarkdown.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+
+defaults write com.apple.finder QLEnableTextSelection -bool TRUE
+killall Finder


### PR DESCRIPTION
Refs.
- https://github.com/toland/qlmarkdown#installation

> Note: QuickLook doesn't allow selecting text by default. If you want to select the text in the markdown preview, you will need to enable text selection in QuickLook by running the following command in Terminal: