### PR TITLE
Introduce `screenfetch`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -251,6 +251,7 @@ brew install nodenv-package-json-engine
 brew install shared-mime-info
 brew install graphviz
 brew install teller
+brew install screenfetch
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info screenfetch

screenfetch: stable 3.9.1, HEAD
Generate ASCII art with terminal, shell, and OS info
https://github.com/KittyKatt/screenFetch
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/screenfetch.rb
License: GPL-3.0
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 739 (30 days), 2,255 (90 days), 10,717 (365 days)
install-on-request: 740 (30 days), 2,254 (90 days), 10,660 (365 days)
build-error: 0 (30 days)
```