### PR TITLE
Introduce "neovim-remote"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -259,6 +259,7 @@ brew install teller
 brew install screenfetch
 brew install hashicorp/tap/terraform
 brew install tfenv
+brew install neovim-remote
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info neovim-remote

neovim-remote: stable 2.4.0 (bottled), HEAD
Control nvim processes using `nvr` command-line tool
https://github.com/mhinz/neovim-remote
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/neovim-remote.rb
License: MIT
==> Dependencies
Required: neovim ✔, python@3.9 ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 38 (30 days), 65 (90 days), 63 (365 days)
install-on-request: 38 (30 days), 65 (90 days), 63 (365 days)
build-error: 0 (30 days)
```