### PR TITLE
Enable to fuzzy finder to repositories as the short name alias

### DIFF
--- a/.bash/aliases.sh
+++ b/.bash/aliases.sh
@@ -59,6 +59,7 @@ alias doc="cd ~/Documents"
 alias download="cd ~/Downloads"
 alias repo="cd ~/Repositories"
 alias repos='cd $(ghq root)/$(ghq list | fzf)'
+alias rp='cd $(ghq root)/$(ghq list | fzf)'
 alias remote_repos='hub browse $(ghq list | fzf | cut -d "/" -f 2,3)'
 alias dotfiles="cd ~/Repositories/github.com/machupicchubeta/dotfiles"
 alias bin="cd ~/bin"

--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -53,6 +53,7 @@ alias doc="cd ~/Documents"
 alias download="cd ~/Downloads"
 alias repo="cd ~/Repositories"
 alias repos='cd $(ghq root)/$(ghq list | fzf)'
+alias rp='cd $(ghq root)/$(ghq list | fzf)'
 alias remote_repos='hub browse $(ghq list | fzf | cut -d "/" -f 2,3)'
 alias dotfiles="cd ~/Repositories/github.com/machupicchubeta/dotfiles"
 alias bin="cd ~/bin"


### PR DESCRIPTION
Since the command is used frequently, it is convenient for me to use it with less typing.