### PR TITLE
Introduce "Microsoft Remote Desktop" via App Store

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -8,6 +8,7 @@ brew install mas
 mas install 497799835 # Xcode
 mas install 411213048 # LadioCast
 mas install 1284863847 # Unsplash Wallpapers
+mas install 1295203466 # Microsoft Remote Desktop
 
 brew tap thoughtbot/formulae
 brew tap homebrew/cask-versions


### PR DESCRIPTION
```
$ mas info 1295203466

Microsoft Remote Desktop 10.6.7 [0.0]
By: Microsoft Corporation
Released: 2021-06-22
Minimum OS: 10.14
Size: 40 MB
From: https://apps.apple.com/us/app/microsoft-remote-desktop/id1295203466?mt=12&uo=4
```

See also:
- https://github.com/machupicchubeta/dotfiles/commit/16e748e817e65d61c9f22c856fe12274540a69a8

> No longer `microsoft-remote-desktop-beta` exists in "Homebrew Cask" and/or "Homebrew Cask versions"