### PR TITLE
Switch to using Neovim development (prerelease) build version

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -109,7 +109,8 @@ brew install zplug
 brew install terminal-notifier
 brew install source-highlight
 brew install luarocks
-brew install neovim
+brew install --HEAD luajit
+brew install --HEAD neovim
 brew install bash-completion
 brew install imagemagick
 brew install gti


### PR DESCRIPTION
I want to try to use "VSCode Neovim Integration", so I switch Neovim from stable version to development (prerelease) build version.
"Neovim 0.5.0 nightly or greater" is required from "VSCode Neovim Integration".

Refs.
- https://github.com/asvetliakov/vscode-neovim#-installation
- https://github.com/neovim/neovim/releases
- https://github.com/neovim/neovim/wiki/Installing-Neovim#homebrew-on-macos-or-linux