### PR TITLE
Introduce "minikube"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -263,6 +263,7 @@ brew install hashicorp/tap/terraform
 brew install tfenv
 brew install neovim-remote
 brew install starship
+brew install minikube
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info minikube

minikube: stable 1.21.0 (bottled), HEAD
Run a Kubernetes cluster locally
https://minikube.sigs.k8s.io/
/usr/local/Cellar/minikube/1.21.0 (9 files, 63.7MB) *
  Poured from bottle on 2021-07-03 at 17:29:46
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/minikube.rb
License: Apache-2.0
==> Dependencies
Build: go ✔, go-bindata ✘
Required: kubernetes-cli ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Analytics
install: 28,477 (30 days), 95,753 (90 days), 401,954 (365 days)
install-on-request: 28,318 (30 days), 95,231 (90 days), 371,176 (365 days)
build-error: 0 (30 days)
```

Refs.
- https://kubernetes.io/docs/tutorials/hello-minikube/
- https://minikube.sigs.k8s.io/docs/start/