### PR TITLE
Introduce "Dust"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -264,6 +264,7 @@ brew install tfenv
 brew install neovim-remote
 brew install starship
 brew install minikube
+brew install dust
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info dust

dust: stable 0.6.0 (bottled), HEAD
More intuitive version of du in rust
https://github.com/bootandy/dust
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/dust.rb
License: Apache-2.0
==> Dependencies
Build: rust ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 3,122 (30 days), 4,061 (90 days), 10,586 (365 days)
install-on-request: 3,118 (30 days), 4,053 (90 days), 10,574 (365 days)
build-error: 0 (30 days)
```