### PR TITLE
Introduce "Choose"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -271,6 +271,7 @@ brew install bandwhich
 brew install grex
 brew install duf
 brew install broot
+brew install choose-rust
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info choose-rust

choose-rust: stable 1.3.2 (bottled)
Human-friendly and fast alternative to cut and (sometimes) awk
https://github.com/theryangeary/choose
Conflicts with:
  choose (because both install a `choose` binary)
  choose-gui (because both install a `choose` binary)
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/choose-rust.rb
License: GPL-3.0-or-later
==> Dependencies
Build: rust ✔
==> Analytics
install: 212 (30 days), 299 (90 days), 434 (365 days)
install-on-request: 211 (30 days), 298 (90 days), 433 (365 days)
build-error: 0 (30 days)
```