### PR TITLE
Introduce "McFly"

### DIFF
--- a/.bash/hooks.sh
+++ b/.bash/hooks.sh
@@ -5,6 +5,7 @@ if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
 if which goenv > /dev/null; then eval "$(goenv init -)"; fi
 if which jenv > /dev/null; then eval "$(jenv init -)"; fi
 if which direnv > /dev/null; then eval "$(direnv hook bash)"; fi
+if which mcfly > /dev/null; then eval "$(mcfly init zsh)"; fi
 
 test -e '/usr/local/etc/bash_completion' && source '/usr/local/etc/bash_completion'
 test -e '/usr/local/opt/fzf/shell/completion.bash' && source '/usr/local/opt/fzf/shell/completion.bash'

--- a/.zsh/hooks.zsh
+++ b/.zsh/hooks.zsh
@@ -7,6 +7,7 @@ if which jenv > /dev/null; then eval "$(jenv init -)"; fi
 if which direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
 if which zoxide > /dev/null; then eval "$(zoxide init zsh)"; fi
 if which starship > /dev/null; then eval "$(starship init zsh)"; fi
+if which mcfly > /dev/null; then eval "$(mcfly init zsh)"; fi
 
 if [ -r '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh' ]; then source '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh'; fi
 if [ -r '/usr/local/opt/fzf/shell/completion.zsh' ]; then source '/usr/local/opt/fzf/shell/completion.zsh'; fi

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -27,6 +27,7 @@ brew tap eugenmayer/dockersync
 brew tap nodenv/nodenv
 brew tap spectralops/tap
 brew tap hashicorp/tap
+brew tap cantino/mcfly
 
 brew unlink vim
 brew upgrade macvim
@@ -281,6 +282,7 @@ brew install curlie
 brew install httpie
 brew install gping
 brew install glances
+brew install mcfly
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info mcfly

cantino/mcfly/mcfly: stable v0.5.7
McFly
https://github.com/cantino/mcfly
Not installed
From: https://github.com/cantino/homebrew-mcfly/blob/HEAD/HomebrewFormula/mcfly.rb
==> Caveats
ONE MORE STEP!

Add the following to the end of your ~/.bashrc, ~/.zshrc, or ~/.config/fish/config.fish file.

Bash:
  eval "$(mcfly init bash)"

Zsh:
  eval "$(mcfly init zsh)"

Fish:
  mcfly init fish | source
```