### PR TITLE
Introduce "gping"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -279,6 +279,7 @@ brew install dog
 brew install xh
 brew install curlie
 brew install httpie
+brew install gping
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info gping

gping: stable 1.2.1 (bottled), HEAD
Ping, but with a graph
https://github.com/orf/gping
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gping.rb
License: MIT
==> Dependencies
Build: rust ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 688 (30 days), 1,158 (90 days), 5,836 (365 days)
install-on-request: 687 (30 days), 1,156 (90 days), 5,827 (365 days)
build-error: 0 (30 days)
```