### PR TITLE
Introduce "HTTPie"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -278,6 +278,7 @@ brew install licensefinder
 brew install dog
 brew install xh
 brew install curlie
+brew install httpie
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
- https://github.com/httpie/httpie

```
$ brew info httpie

httpie: stable 2.4.0 (bottled), HEAD
User-friendly cURL replacement (command-line HTTP client)
https://httpie.io/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/httpie.rb
License: BSD-3-Clause
==> Dependencies
Required: python@3.9 ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 7,458 (30 days), 25,590 (90 days), 174,733 (365 days)
install-on-request: 7,453 (30 days), 25,574 (90 days), 173,334 (365 days)
build-error: 0 (30 days)
```