### PR TITLE
Introduce "Session Manager Plugin for the AWS CLI"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -376,6 +376,7 @@ brew install --cask microsoft-teams
 brew install --cask synergy
 brew install --cask sharemouse
 brew install --cask alacritty
+brew install --cask session-manager-plugin
 
 brew install --cask font-fira-code
 brew install --cask font-fira-code-nerd-font


### PR DESCRIPTION
```
$ brew info --cask session-manager-plugin

session-manager-plugin: 1.2.205.0
https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/session-manager-plugin.rb
==> Name
Session Manager Plugin for the AWS CLI
==> Description
Plugin for AWS CLI to start and end sessions that connect to managed instances
==> Artifacts
sessionmanager-bundle/bin/session-manager-plugin (Binary)
==> Analytics
install: 1,227 (30 days), 3,262 (90 days), 9,424 (365 days)
```