### PR TITLE
Introduce "wasmtime"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -274,6 +274,7 @@ brew install broot
 brew install choose-rust
 brew install detect-secrets
 brew install mongocli
+brew install wasmtime
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info wasmtime

wasmtime: stable 0.29.0 (bottled), HEAD
Standalone JIT-style runtime for WebAssembly, using Cranelift
https://wasmtime.dev/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/wasmtime.rb
License: Apache-2.0
==> Dependencies
Build: rust ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 61 (30 days), 103 (90 days), 103 (365 days)
install-on-request: 61 (30 days), 103 (90 days), 103 (365 days)
build-error: 0 (30 days)
```