### PR TITLE
Revert to use Neovim stable version

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -109,8 +109,7 @@ brew install zplug
 brew install terminal-notifier
 brew install source-highlight
 brew install luarocks
-brew install --HEAD luajit
-brew install --HEAD neovim
+brew install neovim
 brew install bash-completion
 brew install imagemagick
 brew install gti


### PR DESCRIPTION
This reverts the commit 5211756cb37747ca4949e6e3be9cbbc868ebb71d.

I has been switched Neovim from stable version to development (prerelease) build version, for using "VSCode Neovim Integration".
"Neovim 0.5.0 nightly or greater" is required from "VSCode Neovim Integration",
and it stable version 0.5.0 was released, it satisfied to use the plugin condition.

Refs.
- https://github.com/neovim/neovim/releases/tag/v0.5.0
- https://github.com/neovim/neovim/commit/a5ac2f45ff84a688a09479f357a9909d5b914294