### PR TITLE
On-demand loading of the "tabnine" plugin only for file types that require code completion in Vim

### DIFF
--- a/.vim/rc/plug.rc.vim
+++ b/.vim/rc/plug.rc.vim
@@ -57,7 +57,7 @@ if has('vim_starting')
   Plug 'hail2u/vim-css3-syntax', { 'for': [ 'css', 'sass', 'less', 'sacs' ] }
   Plug 'junegunn/vim-emoji'
   Plug 'tyru/open-browser.vim'
-  Plug 'codota/tabnine-vim'
+  Plug 'codota/tabnine-vim', { 'for': ['javascript', 'typescript', 'ruby', 'python', 'css', 'html', 'sass', 'go', 'rust', 'scala', 'java', 'kotlin', 'haskell', 'perl', 'c', 'cpp', 'cs'] }
 
   call plug#end()
 


### PR DESCRIPTION
I chose some filetypes that I'll open in Vim among the languages supported by "tabnine."