### PR TITLE
Prefer to use `go install` instead of `go get`

### DIFF
--- a/bin/setup_go.sh
+++ b/bin/setup_go.sh
@@ -8,4 +8,4 @@ goenv rehash
 
 eval "$(goenv init -)"
 
-go get github.com/fujimura/git-gsub
+go install github.com/fujimura/git-gsub@latest


### PR DESCRIPTION
Warning was:
```
go get: installing executables with 'go get' in module mode is deprecated.
  Use 'go install pkg@version' instead.
  For more information, see https://golang.org/doc/go-get-install-deprecation
  or run 'go help get' or 'go help install'.
```

See also:
- https://golang.org/doc/go-get-install-deprecation

> Deprecation of 'go get' for installing executables
>
> Overview
> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
> In a future Go release, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod.  Specifically, go get will act as if the -d flag were enabled.
>
> What to use instead
> To install an executable in the context of the current module, use go install, without a version suffix, as below.
> This applies version requirements and other directives from the go.mod file in the current directory or a parent directory.

```
go install example.com/cmd
```

> To install an executable while ignoring the current module, use go install with a version suffix like `@v1.2.3` or `@latest`, as below. When used with a version suffix, go install does not read or update the go.mod file in the current directory or a parent directory.

```
# Install a specific version.
go install example.com/cmd@v1.2.3

# Install the highest available version.
go install example.com/cmd@latest
```

> In order to avoid ambiguity, when go install is used with a version suffix, all arguments must refer to main packages in the same module at the same version. If that module has a go.mod file, it must not contain directives like replace or exclude that would cause it to be interpreted differently if it were the main module.