### PR TITLE
Do not use original "vim-easymotion" Vim plugin with Visual Studio Code via "VSCode Neovim"

### DIFF
--- a/.vim/rc/plug.rc.vim
+++ b/.vim/rc/plug.rc.vim
@@ -19,7 +19,9 @@ if has('vim_starting')
   Plug 'lambdalisue/session.vim'
   Plug 'kana/vim-submode'
   Plug 'vim-scripts/grep.vim'
-  Plug 'easymotion/vim-easymotion'
+  if !exists('g:vscode')
+    Plug 'easymotion/vim-easymotion'
+  endif
   Plug 'pbrisbin/vim-mkdir'
   Plug '/usr/local/opt/fzf'
   Plug 'junegunn/fzf.vim'


### PR DESCRIPTION
Refs.
- https://github.com/asvetliakov/vscode-neovim#vim-easymotion

> While the original vim-easymotion functions as expected, it works by replacing your text with markers then restoring back, which leads to broken text and many errors reported in VSCode.