### PR TITLE
Use the "cfn-lint" installed with `brew` instead of `pip`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -284,6 +284,7 @@ brew install glances
 brew install vite
 brew install esbuild
 brew install f2
+brew install cfn-lint
 
 # For Ruby
 brew install openssl

--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -11,6 +11,5 @@ eval "$(pyenv init --path)"
 python3 -m pip install --upgrade pip
 pip3 install --upgrade setuptools wheel
 pip3 list --outdated | awk 'NR>2{print $1}' | xargs --no-run-if-empty pip3 install --upgrade
-pip3 install cfn-lint
 pip3 install pynvim
 /usr/local/bin/pip3 install pynvim


### PR DESCRIPTION
Refs.
- https://github.com/aws-cloudformation/cfn-lint#homebrew-macos

```
$ brew info cfn-lint

cfn-lint: stable 0.54.2 (bottled)
Validate CloudFormation templates against the CloudFormation spec
https://github.com/aws-cloudformation/cfn-python-lint/
Not installed
From:
https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/cfn-lint.rb
License: MIT-0
==> Dependencies
Required: python@3.9 ✔, six ✔
==> Analytics
install: 4,900 (30 days), 10,979 (90 days), 42,746 (365 days)
install-on-request: 4,901 (30 days), 10,979 (90 days), 42,744 (365 days)
build-error: 0 (30 days)
```