### PR TITLE
Use ".NET SDK" instead of ".Net Runtime"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -356,7 +356,7 @@ brew install --cask google-earth-pro
 brew install --cask zoom
 brew install --cask spotify
 brew install --cask chromedriver
-brew install --cask dotnet
+brew install --cask dotnet-sdk
 brew install --cask visual-studio
 brew install --cask visual-studio-code
 brew install --cask dynamodb-local


### PR DESCRIPTION
```
$ brew info --cask dotnet-sdk

dotnet-sdk: 5.0.401,846d5680-b804-4903-8d8d-255804bcfaeb:436101afc96998f75efb452f5ded3c1a
https://www.microsoft.com/net/core#macos
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/dotnet-sdk.rb
==> Name
.NET SDK
==> Description
Developer platform
==> Artifacts
dotnet-sdk-5.0.401-osx-x64.pkg (Pkg)
/usr/local/share/dotnet/dotnet (Binary)
==> Analytics
install: 1,100 (30 days), 3,504 (90 days), 15,211 (365 days)
```

```
$ brew info --cask dotnet

dotnet: 5.0.10,0a1577a6-a7f1-4da0-ae64-9003ff8badb5:3b3a9291a0bdcb5591afab9e842272db
https://www.microsoft.com/net/core#macos
/usr/local/Caskroom/dotnet/5.0.10,0a1577a6-a7f1-4da0-ae64-9003ff8badb5:3b3a9291a0bdcb5591afab9e842272db (29.3MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/dotnet.rb
==> Name
.Net Runtime
==> Description
Developer platform
==> Artifacts
dotnet-runtime-5.0.10-osx-x64.pkg (Pkg)
/usr/local/share/dotnet/dotnet (Binary)
==> Analytics
install: 531 (30 days), 1,739 (90 days), 7,704 (365 days)
```