### PR TITLE
Use `OpenSSL 1.1` until `OpenSSL for Ruby` will support `OpenSSL 3.0`

### DIFF
--- a/.bash/variables.sh
+++ b/.bash/variables.sh
@@ -43,4 +43,4 @@ export GREP_OPTIONS='--color=auto'
 
 export GUILE_TLS_CERTIFICATE_DIRECTORY=/usr/local/etc/gnutls/
 
-export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl"
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl@1.1"

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -44,4 +44,4 @@ export GREP_OPTIONS='--color=auto'
 
 export GUILE_TLS_CERTIFICATE_DIRECTORY=/usr/local/etc/gnutls/
 
-export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl"
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl@1.1"

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -288,6 +288,7 @@ brew install cfn-lint
 
 # For Ruby
 brew install openssl
+brew install openssl@1.1
 brew install readline
 brew install ruby-build
 brew install rbenv


### PR DESCRIPTION
It seems to be still in preparation at the moment.

- https://github.com/ruby/openssl/issues/369

```
$ brew info openssl@1.1

openssl@1.1: stable 1.1.1l (bottled) [keg-only]
Cryptography and SSL/TLS Toolkit
https://openssl.org/
/usr/local/Cellar/openssl@1.1/1.1.1l_1 (8,073 files, 18.5MB)
  Poured from bottle on 2021-10-09 at 17:50:03
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/openssl@1.1.rb
License: OpenSSL
==> Dependencies
Required: ca-certificates ✔
==> Caveats
A CA file has been bootstrapped using certificates from the system
keychain. To add additional certificates, place .pem files in
  /usr/local/etc/openssl@1.1/certs

and run
  /usr/local/opt/openssl@1.1/bin/c_rehash

openssl@1.1 is keg-only, which means it was not symlinked into /usr/local,
because macOS provides LibreSSL.

If you need to have openssl@1.1 first in your PATH, run:
  echo 'export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"' >> ~/.zshrc

For compilers to find openssl@1.1 you may need to set:
  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
  export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"

For pkg-config to find openssl@1.1 you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"

==> Analytics
install: 1,034,525 (30 days), 2,791,466 (90 days), 9,665,014 (365 days)
install-on-request: 40,532 (30 days), 166,402 (90 days), 971,361 (365 days)
build-error: 0 (30 days)
```