### PR TITLE
Introduce "aws-vault"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -285,6 +285,7 @@ brew install vite
 brew install esbuild
 brew install f2
 brew install cfn-lint
+brew install aws-vault
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info aws-vault

Warning: Treating aws-vault as a formula. For the cask, use homebrew/cask/aws-vault
aws-vault: stable 6.3.1 (bottled)
Securely store and access AWS credentials in development environments
https://github.com/99designs/aws-vault
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/aws-vault.rb
License: MIT
==> Dependencies
Build: go ✔
==> Analytics
install: 1,188 (30 days), 3,323 (90 days), 3,405 (365 days)
install-on-request: 1,182 (30 days), 3,311 (90 days), 3,393 (365 days)
build-error: 0 (30 days)
```