### PR TITLE
Make it use easier `git-switch` and `git-restore` by aliases

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -23,11 +23,24 @@
   delete-branch = branch -D
   ch = checkout
   chb = checkout -b
+  sw = switch
+  swc = switch --create
+  swcf = switch --force-create
+  new-branch = swc
+  new-branch-force = swfc
   crp = cherry-pick
   fc = fetch
   ft = fetch --tags
   t = tag
   rb = rebase
+  rst = restore
+  rsts = restore --staged
+  rstsw = restore --staged --worktree
+  rt = rst
+  rts = rsts
+  rtsw = rstsw
+  rt-s = rts
+  rt-sw = rtsw
   sh = show
   changelog = "!f() { git tag | grep RELEASE | tail -n 1 | xargs -I{} git log {}...\"`git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@'`\" --oneline | grep 'Merge pull request' | awk '{ print $1 }' | emojify | xargs git show; }; f;"
 #  lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --
@@ -56,8 +69,11 @@
   db = !git checkout-default-branch
   prr-upstream = "!f() { git checkout $(git show-default-branch) && git pull --rebase --prune upstream $(git show-default-branch); }; f"
   ch- = "!f() { git checkout $(git branch | grep -v \"`git show-default-branch`\" | fzf); }; f"
+  sw- = ch-
   chb-origin = "!f() { git branch -r | grep origin | grep -v \"`git show-default-branch`\" | fzf | sed 's/origin\\///' | xargs -I {} git checkout -b {} origin/{}; }; f"
+  swc-origin = chb-origin
   chb-upstream = "!f() { git branch -r | grep upstream | grep -v \"`git show-default-branch`\" | fzf | sed 's/upstream\\///' | xargs -I {} git checkout -b {} upstream/{}; }; f"
+  swc-upstream = chb-upstream
 [color]
   ui = true
 [apply]


### PR DESCRIPTION
Instead of "git-checkout", I think I'll use the new commands "git-switch" and "git-restore" for different contexts.
That's what I thought after reading this Blog post.
- https://medium.com/blue-harvest-tech-blog/git-2-23-0-forget-about-checkout-and-switch-to-restore-ac2682b737b3