### PR TITLE
Remove "do nothing" keymaps in Vim

### DIFF
--- a/.vim/rc/init.rc.vim
+++ b/.vim/rc/init.rc.vim
@@ -20,14 +20,6 @@ let g:mapleader = ','
 " Use <LocalLeader> in filetype plugin.
 let g:maplocalleader = 'm'
 
-" Release keymappings for plug-in.
-nnoremap ;  <Nop>
-xnoremap ;  <Nop>
-nnoremap m  <Nop>
-xnoremap m  <Nop>
-nnoremap ,  <Nop>
-xnoremap ,  <Nop>
-
 if IsWindows()
   " Exchange path separator.
   set shellslash


### PR DESCRIPTION
I had copied the settings of a famous person in Vim, but it seemed unnecessary for me, so I remove that keymaps.

Refs.
- https://github.com/Shougo/shougo-s-github/commit/168a1c83f44678bf3c86f0448dcc603d7b52cd06#diff-fc68214273da36ad5f000127411d4a2ae7b004c8770692b76180f702c5247dd8R147-R160
- https://github.com/Shougo/shougo-s-github/commit/e681c91cf3067b20ba9d1ad464e6d068446b7687#diff-b7cc04b814d14368a6ca9953695a8439a7ef3be92c8265874359ca80904d1babR19-R32
- https://github.com/Shougo/shougo-s-github/commit/fbc018b76a8cacb8219399cc349cdd962c469274#diff-5537b1049f319c7cc646806c4e369a81810f6d13e4ae6bc714a71c3927615994R5-R14
- https://github.com/machupicchubeta/dotfiles/commit/2c3a98a7e5bf7fbcaf0ae387a2e8c95abbf7d40d#diff-09e2f4afe0d1fd06d32538d94e4aa42d6a7abf7cc200f8eb6d2f58b640a8e671R16-R29

Recently, I noticed that the mark command and the s-key were behaving in an unintended way in "VSCode Neovim", and when I reviewed the settings, I was able to get the intended behavior back by removing the keymaps.
The "m" keymap seemed to be the cause of the problem, but the "," and ";" keymaps seemed to be unnecessary also for me, so I remove them at the same time.