### PR TITLE
Make the setup script robust; Prevent the "Invalid index" error, stopping the setup unintentionally

### DIFF
--- a/bin/setup_command_line_tools.sh
+++ b/bin/setup_command_line_tools.sh
@@ -12,11 +12,15 @@ tell application "System Events"
     click button "Agree" of window "License Agreement"
     repeat
       delay 0.5
-      if name of first button of first window contains "Done" then
-        exit repeat
-      end if
+      try
+        if name of first button of first window contains "Done" then
+          click button "Done" of first window
+          exit repeat
+        end if
+      on error
+        -- do nothing
+      end try
     end repeat
-    click button "Done" of first window
   end tell
 end tell
 EOD


### PR DESCRIPTION
After upgrading my macOS to Monterey, it has getting an "Invalid index" error on button click commands when installing "Command Line Developer Tools" as the focus shifts to other apps.

Error was:
```
267:273: execution error: System Events got an error: Can’t get window 1 of process "Install Command Line Developer Tools". Invalid index. (-1719)
```