### PR TITLE
Stop installing `docker-sync` gem

### DIFF
--- a/rbenv/default-gems
+++ b/rbenv/default-gems
@@ -13,4 +13,3 @@ powder
 reek
 neovim
 solargraph
-docker-sync


### PR DESCRIPTION
As far as I remember, I think I got an error when installing `docker-sync` gem with Ruby 3.x.
I didn't feel the benefit of installing the `docker-sync` gem because I wasn't dissatisfied with Docker's behavior without it.

This commit essentially reverts the commit.
- https://github.com/machupicchubeta/dotfiles/commit/9f4c2ef93231bb2dfe3e592606744ff14a05ed45