### PR TITLE
Install "Terraform" and "Terragrunt" via `tfenv` and `tgswitch`, respectively, instead of via "Homebrew"

### DIFF
--- a/.zsh/tgswitch.zsh
+++ b/.zsh/tgswitch.zsh
@@ -1,0 +1,9 @@
+load-tgswitch() {
+  local tgswitchrc_path=".tgswitchrc"
+
+  if [ -f "$tgswitchrc_path" ]; then
+    tgswitch
+  fi
+}
+add-zsh-hook chpwd load-tgswitch
+load-tgswitch

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -26,18 +26,13 @@ brew tap elastic/tap
 brew tap eugenmayer/dockersync
 brew tap nodenv/nodenv
 brew tap spectralops/tap
-brew tap hashicorp/tap
+brew tap warrensbox/tap
 
 brew unlink vim
 brew upgrade macvim
 brew unlink macvim
 brew upgrade vim
 brew link vim
-brew unlink hashicorp/tap/terraform
-brew upgrade tfenv
-brew unlink tfenv
-brew upgrade hashicorp/tap/terraform
-brew link hashicorp/tap/terraform
 brew update
 brew upgrade --fetch-HEAD
 
@@ -183,7 +178,6 @@ brew install ansible-lint
 brew install firebase-cli
 brew install logrotate
 brew install pre-commit
-brew install terragrunt
 brew install protobuf
 brew install pv
 brew install git-secrets
@@ -258,8 +252,6 @@ brew install shared-mime-info
 brew install graphviz
 brew install teller
 brew install screenfetch
-brew install hashicorp/tap/terraform
-brew install tfenv
 brew install neovim-remote
 brew install starship
 brew install minikube
@@ -286,6 +278,8 @@ brew install esbuild
 brew install f2
 brew install cfn-lint
 brew install aws-vault
+brew install tfenv
+brew install warrensbox/tap/tgswitch
 
 # For Ruby
 brew install openssl

--- a/bin/setup_terraform.sh
+++ b/bin/setup_terraform.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+
+tfenv install latest
+tfenv use latest


### PR DESCRIPTION
I want to make it easier to manage the versions of libraries and tools used by each product.

```
$ brew info tfenv

tfenv: stable 2.2.2 (bottled), HEAD
Terraform version manager inspired by rbenv
https://github.com/tfutils/tfenv
Conflicts with:
  terraform (because tfenv symlinks terraform binaries)
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/tfenv.rb
License: MIT
==> Options
--HEAD
        Install HEAD version
==> Analytics
install: 7,254 (30 days), 21,080 (90 days), 98,192 (365 days)
install-on-request: 7,233 (30 days), 21,011 (90 days), 97,891 (365 days)
build-error: 0 (30 days)
```

```
$ brew info warrensbox/tap/tgswitch

warrensbox/tap/tgswitch: stable 0.5.378
The tgswitch command lets you switch between terragrunt versions.
https://warrensbox.github.io/tgswitch
Not installed
From: https://github.com/warrensbox/homebrew-tap/blob/HEAD/Formula/tgswitch.rb
==> Caveats
Type 'tgswitch' on your command line and choose the terragrunt version that you want from the dropdown. This command currently only works on MacOs and Linux
```

Refs.
- https://github.com/tfutils/tfenv#tfenv-install-version
- https://github.com/tfutils/tfenv#tfenv-use-version
- https://github.com/warrensbox/tgswitch#use-tgswitchrc-file