### PR TITLE
Introduce "Auth0 CLI"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -27,6 +27,7 @@ brew tap eugenmayer/dockersync
 brew tap nodenv/nodenv
 brew tap spectralops/tap
 brew tap warrensbox/tap
+brew tap auth0/auth0-cli
 
 brew unlink vim
 brew upgrade macvim
@@ -280,6 +281,7 @@ brew install cfn-lint
 brew install aws-vault
 brew install tfenv
 brew install warrensbox/tap/tgswitch
+brew install auth0
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info auth0

auth0/auth0-cli/auth0: stable 0.11.3
Auth0 command-line tool to supercharge your developer workflow
https://auth0.github.io/auth0-cli
Not installed
From: https://github.com/auth0/homebrew-auth0-cli/blob/HEAD/auth0.rb
License: MIT
==> Caveats
Thanks for installing the Auth0 CLI
```