### PR TITLE
Make sure to link "node-build"; Enable to use `nodenv install` command

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -94,6 +94,7 @@ brew install redis
 brew install memcached
 brew install node
 brew install node-build --HEAD
+brew link node-build
 brew install nodenv
 brew install watchman
 brew install z


### PR DESCRIPTION
Avoid the command not found error.
```
nodenv: no such command `install'
```