### PR TITLE
Remove "Pow" which is no longer maintained

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -154,7 +154,6 @@ brew install cowsay
 brew install figlet
 brew install asciiquarium
 brew install cmatrix
-brew install pow
 brew install yarn
 brew install nss
 brew install cheat


### PR DESCRIPTION
> Deprecated because it has an archived upstream repository!

```
$ brew info pow

pow: stable 0.6.0 (bottled)
Zero-config Rack server for local apps on macOS
http://pow.cx/
Deprecated because it has an archived upstream repository!
/usr/local/Cellar/pow/0.6.0 (691 files, 10.3MB) *
  Poured from bottle on 2022-01-16 at 23:33:47
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/pow.rb
==> Dependencies
Required: node ✔
==> Requirements
Required: macOS ✔
==> Caveats
Create the required host directories:
  mkdir -p ~/Library/Application\ Support/Pow/Hosts
  ln -s ~/Library/Application\ Support/Pow/Hosts ~/.pow

Setup port 80 forwarding and launchd agents:
  sudo pow --install-system
  pow --install-local

Load launchd agents:
  sudo launchctl load -w /Library/LaunchDaemons/cx.pow.firewall.plist
  launchctl load -w ~/Library/LaunchAgents/cx.pow.powd.plist
==> Analytics
install: 25 (30 days), 85 (90 days), 434 (365 days)
install-on-request: 25 (30 days), 85 (90 days), 435 (365 days)
build-error: 0 (30 days)
```

- https://github.com/basecamp/pow
- https://github.com/Homebrew/homebrew-core/blob/ef3d666967b875d6cfb3dbad4cc7f965dcb43854/Formula/pow.rb#L17-L19

```
  # The related GitHub repository (basecamp/pow) was archived sometime between
  # 2018-06-11 and 2019-04-10 (referencing Wayback Machine snapshots)
  deprecate! date: "2021-04-21", because: :repo_archived
```