### PR TITLE
Stop using "zsh-navigation-tools" since the repository has been removed

### DIFF
--- a/.zsh/hooks.zsh
+++ b/.zsh/hooks.zsh
@@ -8,7 +8,6 @@ if which direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
 if which zoxide > /dev/null; then eval "$(zoxide init zsh)"; fi
 if which starship > /dev/null; then eval "$(starship init zsh)"; fi
 
-if [ -r '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh' ]; then source '/usr/local/opt/zsh-navigation-tools/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh'; fi
 if [ -r '/usr/local/opt/fzf/shell/completion.zsh' ]; then source '/usr/local/opt/fzf/shell/completion.zsh'; fi
 if [ -r '/usr/local/opt/fzf/shell/key-bindings.zsh' ]; then source '/usr/local/opt/fzf/shell/key-bindings.zsh'; fi
 if [ -r '/usr/local/opt/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh' ]; then source '/usr/local/opt/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh'; fi

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -99,7 +99,6 @@ brew install nodenv
 brew install watchman
 brew install z
 brew install zsh-completions
-brew install zsh-navigation-tools
 brew install zsh-autosuggestions
 brew install zsh-syntax-highlighting
 brew install zplug


### PR DESCRIPTION
> Deprecated because it has a removed upstream repository!

```
$ brew info zsh-navigation-tools

zsh-navigation-tools: stable 2.2.7 (bottled)
Zsh curses-based tools, e.g. multi-word history searcher
https://github.com/psprint/zsh-navigation-tools
Deprecated because it has a removed upstream repository!
/usr/local/Cellar/zsh-navigation-tools/2.2.7 (38 files, 291.0KB) *
  Poured from bottle on 2022-01-16 at 23:30:26
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/zsh-navigation-tools.rb
License: GPL-3.0-only or MIT
==> Caveats
To run zsh-navigation-tools, add the following at the end of your .zshrc:
  source /usr/local/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh

You will also need to force reload of your .zshrc:
  source ~/.zshrc
==> Analytics
install: 83 (30 days), 365 (90 days), 1,309 (365 days)
install-on-request: 82 (30 days), 365 (90 days), 1,307 (365 days)
build-error: 0 (30 days)
```

- https://github.com/Homebrew/homebrew-core/blob/ef3d666967b875d6cfb3dbad4cc7f965dcb43854/Formula/zsh-navigation-tools.rb#L22