### PR TITLE
Remove the key mapping for "Escape" in Vim, Neovim

### DIFF
--- a/.vim/rc/mappings.rc.vim
+++ b/.vim/rc/mappings.rc.vim
@@ -231,14 +231,6 @@ xnoremap s :s//g<Left><Left>
 " endfunction
 "}}}
 
-" Easy escape."{{{
-inoremap jj           <ESC>
-cnoremap <expr> j
-      \ getcmdline()[getcmdpos()-2] ==# 'j' ? "\<BS>\<C-c>" : 'j'
-
-inoremap j<Space>     j
-"}}}
-
 " a>, i], etc... "{{{
 " <angle>
 onoremap aa  a>

--- a/.vim/rc/neovim.rc.vim
+++ b/.vim/rc/neovim.rc.vim
@@ -1,6 +1,4 @@
 tnoremap   <ESC>      <C-\><C-n>
-tnoremap   jj         <C-\><C-n>
-tnoremap   j<Space>   j
 
 nnoremap <Leader>t    :<C-u>terminal<CR>
 nnoremap !            :<C-u>terminal<Space>


### PR DESCRIPTION
It's annoying when I can't type `jj`.