### PR TITLE
Introduce `jless`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -281,6 +281,7 @@ brew install aws-vault
 brew install tfenv
 brew install warrensbox/tap/tgswitch
 brew install auth0
+brew install jless
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info jless

jless: stable 0.7.1 (bottled)
Command-line pager for JSON data
https://pauljuliusmartinez.github.io/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/jless.rb
License: MIT
==> Dependencies
Build: rust ✔
==> Analytics
install: 39 (30 days), 39 (90 days), 39 (365 days)
install-on-request: 39 (30 days), 39 (90 days), 39 (365 days)
build-error: 0 (30 days)
```