### PR TITLE
Introduce "Terraform LSP"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -282,6 +282,7 @@ brew install tfenv
 brew install warrensbox/tap/tgswitch
 brew install auth0
 brew install jless
+brew install terraform-lsp
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info terraform-lsp

terraform-lsp: stable 0.0.12 (bottled), HEAD
Language Server Protocol for Terraform
https://github.com/juliosueiras/terraform-lsp
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/terraform-lsp.rb
License: MIT
==> Dependencies
Build: go ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 14 (30 days), 14 (90 days), 14 (365 days)
install-on-request: 14 (30 days), 14 (90 days), 14 (365 days)
build-error: 0 (30 days)
```