### PR TITLE
No longer needed the workaround, it seems

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -172,6 +172,3 @@ alias lzd='lazydocker'
 
 alias lg='lazygit'
 alias lzg='lazygit'
-
-# alias brew='PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin brew'
-alias brew='env PATH=${PATH/$PYENV_ROOT\/shims:/} brew'


### PR DESCRIPTION
When I tried it, the warning was no longer generated without the workaround code.

Here is the commit where the workaround code was introduced.
- https://github.com/machupicchubeta/dotfiles/commit/7fa76fbcff330f07ad1940dfb139b1fda9bf28be