### PR TITLE
No longer available to install "font-source-han-code-jp" via homebrew-cask-fonts

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -419,7 +419,6 @@ brew install --cask font-cascadia-code
 brew install --cask font-cascadia-code-pl
 brew install --cask font-jetbrains-mono
 brew install --cask font-jetbrains-mono-nerd-font
-brew install --cask font-source-han-code-jp
 brew install --cask font-ibm-plex
 
 brew cu --all --cleanup --yes


### PR DESCRIPTION
I am sorry to hear that. I will be looking for other ways to install it.

See also:
- https://github.com/Homebrew/homebrew-cask-fonts/pull/3903
- https://github.com/Homebrew/homebrew-cask-fonts/pull/3898#issuecomment-821838947