### PR TITLE
Stop to use "nodenv-package-json-engine" formula which cannot be installed due to an error

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -36,7 +36,6 @@ brew tap mongodb/brew
 brew tap clementtsang/bottom
 brew tap elastic/tap
 brew tap eugenmayer/dockersync
-brew tap nodenv/nodenv
 brew tap spectralops/tap
 brew tap warrensbox/tap
 brew tap auth0/auth0-cli
@@ -257,7 +256,6 @@ brew install graphicsmagick
 brew install unox
 brew install fswatch
 brew install unison
-brew install nodenv-package-json-engine
 brew install shared-mime-info
 brew install graphviz
 brew install teller


### PR DESCRIPTION
It seems no longer maintains.

Errors were:
```
==> Tapping nodenv/nodenv
Cloning into '/opt/homebrew/Library/Taps/nodenv/homebrew-nodenv'...
remote: Enumerating objects: 582, done.
remote: Total 582 (delta 0), reused 0 (delta 0), pack-reused 582
Receiving objects: 100% (582/582), 122.88 KiB | 5.12 MiB/s, done.
Resolving deltas: 100% (299/299), done.
Error: Invalid formula: /opt/homebrew/Library/Taps/nodenv/homebrew-nodenv/Formula/node-build-jxcore.rb
node-build-jxcore: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the nodenv/nodenv tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/nodenv/homebrew-nodenv/Formula/node-build-jxcore.rb:8

Error: Invalid formula: /opt/homebrew/Library/Taps/nodenv/homebrew-nodenv/Formula/node-build-prerelease.rb
node-build-prerelease: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the nodenv/nodenv tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/nodenv/homebrew-nodenv/Formula/node-build-prerelease.rb:8

Error: Cannot tap nodenv/nodenv: invalid syntax in tap!
```

```
Warning: No available formula with the name "nodenv-package-json-engine".
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching taps on GitHub...
Error: No formulae found in taps.
```