### PR TITLE
Stop to use "bench" command which cannot be installed due to an error

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -195,7 +195,6 @@ brew install testssl
 brew install kubernetes-helm
 brew install gradle
 brew install azure-cli
-brew install bench
 brew install circleci
 brew install eslint
 brew install iso-codes


### PR DESCRIPTION
Error was:
```
$ brew install bench

Error: bench: no bottle available!
You can try to install from source with:
  brew install --build-from-source bench
Please note building from source is unsupported. You will encounter build
failures with some formulae. If you experience any issues please create pull
requests instead of asking for help on Homebrew's GitHub, Twitter or any other
official channels.
```