### PR TITLE
Use `-d` operator instead of `-f` to determine if a directory exists

### DIFF
--- a/bin/put_settings.sh
+++ b/bin/put_settings.sh
@@ -25,7 +25,7 @@ fi
 if [ -L "$XDG_CONFIG_HOME/nvim" ]; then
   unlink "$XDG_CONFIG_HOME/nvim"
 fi
-if [ -f "$SETTINGS_PATH/.vim" ]; then
+if [ -d "$SETTINGS_PATH/.vim" ]; then
   ln -s "$SETTINGS_PATH/.vim" "$XDG_CONFIG_HOME/nvim"
 fi
 


### PR DESCRIPTION
This commit corrects a typographical error in a previous commit.
- https://github.com/machupicchubeta/dotfiles/commit/ce1ca02553469e00718a8836eaa43b68cf2c3cd0