### PR TITLE
No longer needed "$HOME/Applications" directory

### DIFF
--- a/bin/setup_directories.sh
+++ b/bin/setup_directories.sh
@@ -6,11 +6,6 @@ if [ ! -d "$HOME/tmp" ]; then
   mkdir "$HOME/tmp"
 fi
 
-echo -e "\nCreate own Applications directory"
-if [ ! -d "$HOME/Applications" ]; then
-  mkdir "$HOME/Applications"
-fi
-
 echo -e "\nChange screencapture store directory"
 SCREENSHOTS_PATH="$HOME/Screenshots"
 if [ ! -d "$SCREENSHOTS_PATH" ]; then


### PR DESCRIPTION
This directory was originally intended by me to be used by "Homebrew Cask".
However, the default setting of "Homebrew Cask" was changed and it became the "/Applications" directory.
Since the directory is not used for any other purpose, it is no longer created by the setup script.

See also:
- https://github.com/Homebrew/homebrew-cask/issues/13201
- https://github.com/Homebrew/homebrew-cask/issues/2534
- https://github.com/Homebrew/homebrew-cask/pull/13966
- https://github.com/Homebrew/homebrew-cask/commit/47383169de5c2128302d928c8d59b7eda3ab98e7