### PR TITLE
Prevent `jenv` command error that fails to create a symbolic link

### DIFF
--- a/bin/setup_java.sh
+++ b/bin/setup_java.sh
@@ -4,6 +4,7 @@ set -eu
 if [ ! -L '/Library/Java/JavaVirtualMachines/openjdk.jdk' ]; then
   sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
 fi
-jenv add $(/usr/libexec/java_home)
 
 eval "$(jenv init -)"
+
+jenv add $(/usr/libexec/java_home)


### PR DESCRIPTION
It looks that the `.jenv` directory had not yet been created when the error occurred.
It seems to be run "init" command necessary before "add" command.

Error was:
```
ln: failed to create symbolic link '/Users/machupicchubeta/.jenv/versions/openjdk64-17.0.2': No such file or directory
```