### PR TITLE
Put together setup scripts on "bin" directory

### DIFF
--- a/bin/enable_to_key-repeating_on_vscode.sh
+++ b/bin/enable_to_key-repeating_on_vscode.sh
@@ -1,2 +1,5 @@
+#!/bin/bash
+set -eu
+
 defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false
 defaults write com.microsoft.VSCodeInsiders ApplePressAndHoldEnabled -bool false


### PR DESCRIPTION
It aims to prevent execution omissions by keeping them in one directory.