### PR TITLE
Use `docker-compose` plugin of "Oh My Zsh"

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -139,8 +139,6 @@ alias start_postgres="pg_ctl -D $HOMEBREW_PREFIX/var/postgres -l logfile start"
 alias dk='docker'
 alias dkps='docker ps'
 alias dke='docker exec --interactive --tty'
-alias dkc='docker-compose'
-alias dkcps='docker-compose ps'
 
 alias -g L='| less'
 alias -g G='| grep'

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -26,7 +26,7 @@ apply = ["source"]
 [plugins.ohmyzsh-plugins]
 github = "ohmyzsh/ohmyzsh"
 dir = "plugins"
-use = ["{bundler/bundler,git/git,history/history,macos/macos,terraform/terraform,z/z}.plugin.zsh"]
+use = ["{bundler/bundler,docker-compose/docker-compose,git/git,history/history,macos/macos,terraform/terraform,z/z}.plugin.zsh"]
 apply = ["source"]
 
 [plugins.ohmyzsh-plugin-docker]


### PR DESCRIPTION
I think it is able to replace the aliases that I added.

See also:
- https://github.com/ohmyzsh/ohmyzsh/tree/c96fc233c4903ba75fba5bc55e7f91f9dc8e460e/plugins/docker-compose

I'm considering removing the alias setting for `bash` in the future, and hope to be able to use plugins in `bash` as well as `zsh` by using "sheldon" to load the configuration files.