### PR TITLE
Enable to install "Source Han Code JP" to the user font directory

### DIFF
--- a/bin/setup_fonts.sh
+++ b/bin/setup_fonts.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eu
 
+USER_FONT_DIR="$HOME/Library/Fonts/"
+
+echo -e "\nCopy SFMono fonts to User font directory"
 TERMINAL_APP_PATH=""
 if [ -d "/System/Applications/Utilities/Terminal.app" ]; then
   TERMINAL_APP_PATH="/System/Applications/Utilities/Terminal.app"
@@ -8,5 +11,14 @@ elif [ -d "/Applications/Utilities/Terminal.app" ]; then
   TERMINAL_APP_PATH="/Applications/Utilities/Terminal.app"
 fi
 if [ -n "$TERMINAL_APP_PATH" ]; then
-  cp -f "$TERMINAL_APP_PATH"/Contents/Resources/Fonts/*.otf "$HOME/Library/Fonts/"
+  cp -f "$TERMINAL_APP_PATH"/Contents/Resources/Fonts/*.otf "$USER_FONT_DIR"
+fi
+
+echo -e "\nInstall \"Source Han Code JP\" to User font directory"
+curl -fsSL https://github.com/adobe-fonts/source-han-code-jp/archive/refs/tags/2.012R.tar.gz | tar -xzC /tmp/
+SOURCE_HAN_CODE_JP_TEMP_DIR="/tmp/source-han-code-jp-2.012R"
+if [ -d "$SOURCE_HAN_CODE_JP_TEMP_DIR" ]; then
+  find "$USER_FONT_DIR" -type f -name "SourceHanCodeJP-*" | xargs rm --recursive --force
+  find "$SOURCE_HAN_CODE_JP_TEMP_DIR" -type f -name '*.ttc' -or -name '*.otf' -exec mv --target-directory="$USER_FONT_DIR" {} +
+  rm --recursive --force "$SOURCE_HAN_CODE_JP_TEMP_DIR"
 fi

--- a/bin/setup_fonts.sh
+++ b/bin/setup_fonts.sh
@@ -3,7 +3,7 @@ set -eu
 
 USER_FONT_DIR="$HOME/Library/Fonts/"
 
-echo -e "\nCopy SFMono fonts to User font directory"
+echo -e "\nCopy SFMono fonts to the user font directory"
 TERMINAL_APP_PATH=""
 if [ -d "/System/Applications/Utilities/Terminal.app" ]; then
   TERMINAL_APP_PATH="/System/Applications/Utilities/Terminal.app"
@@ -14,7 +14,7 @@ if [ -n "$TERMINAL_APP_PATH" ]; then
   cp -f "$TERMINAL_APP_PATH"/Contents/Resources/Fonts/*.otf "$USER_FONT_DIR"
 fi
 
-echo -e "\nInstall \"Source Han Code JP\" to User font directory"
+echo -e "\nInstall \"Source Han Code JP\" to the user font directory"
 curl -fsSL https://github.com/adobe-fonts/source-han-code-jp/archive/refs/tags/2.012R.tar.gz | tar -xzC /tmp/
 SOURCE_HAN_CODE_JP_TEMP_DIR="/tmp/source-han-code-jp-2.012R"
 if [ -d "$SOURCE_HAN_CODE_JP_TEMP_DIR" ]; then


### PR DESCRIPTION
Refs.
- https://github.com/adobe-fonts/source-han-code-jp
- https://github.com/adobe-fonts/source-han-code-jp/releases

Unfortunately, it is no longer possible to install "font-source-han-code-jp" from homebrew-cask-fonts.
So, I add this script to download and install it in the user font directory by myself.

See also:
- https://github.com/Homebrew/homebrew-cask-fonts/pull/3903
- https://github.com/Homebrew/homebrew-cask-fonts/pull/3898#issuecomment-821838947
- https://github.com/machupicchubeta/dotfiles/pull/346
- https://github.com/machupicchubeta/dotfiles/commit/ff864fb0b19ebfb138aa7806484407ca79ece984
