### PR TITLE
Introduce "im-select"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -44,6 +44,7 @@ brew tap eugenmayer/dockersync
 brew tap spectralops/tap
 brew tap warrensbox/tap
 brew tap auth0/auth0-cli
+brew tap daipeihust/tap
 
 brew unlink vim
 brew upgrade macvim
@@ -296,6 +297,7 @@ brew install auth0
 brew install jless
 brew install terraform-lsp
 brew install sheldon
+brew install im-select
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
When I using Visual Studio Code's Neovim extension, unintentional overwriting occurs due to operations such as moving the cursor without realizing that the input is in Japanese input mode instead of English input mode.
I'm planning to build a mechanism to prevent this using "im-select".

```
$ brew info im-select

daipeihust/tap/im-select: stable 1.0.1
Switch your input method through terminal
https://github.com/daipeihust/im-select
Not installed
From: https://github.com/daipeihust/homebrew-tap/blob/HEAD/im-select.rb
License: MIT
```