### PR TITLE
Prevent unintentional overwriting in Japanese input in normal mode with Visual Studio Code's Neovim extension

### DIFF
--- a/.vim/rc/im-select.rc.vim
+++ b/.vim/rc/im-select.rc.vim
@@ -1,0 +1,16 @@
+function! MakeInputSourceToEnglish() abort
+  if trim(system("uname -m")) == "arm64"
+    let s:im_select_path = '/opt/homebrew/bin/im-select'
+  else
+    let s:im_select_path = '/usr/local/bin/im-select'
+  endif
+
+  if executable(s:im_select_path)
+    execute 'silent !' . s:im_select_path . ' com.apple.keylayout.ABC'
+  endif
+endfunction
+
+augroup im_select
+  autocmd!
+  autocmd BufNew,BufEnter,InsertLeave * call MakeInputSourceToEnglish()
+augroup END

--- a/.vim/rc/vimrc
+++ b/.vim/rc/vimrc
@@ -69,3 +69,7 @@ if !exists('g:vscode')
   call s:source_rc('rails')
   call s:source_rc('reek')
 endif
+
+if exists('g:vscode')
+  call s:source_rc('im-select')
+endif


### PR DESCRIPTION
When I using Visual Studio Code's Neovim extension, unintentional overwriting occurs due to operations such as moving the cursor without realizing that the input is in Japanese input mode instead of English input mode.

This commit prevents unintentional overwriting of code by forcibly switching the macOS input mode to English when opening a new file on Visual Studio Code, focusing again on a file already open, or leaving Neovim's input mode.