### PR TITLE
Make sure to identify the architecture of the machine in Vim script

### DIFF
--- a/.vim/rc/filetype.rc.vim
+++ b/.vim/rc/filetype.rc.vim
@@ -32,7 +32,7 @@
 "   autocmd FileType html
 "        \ setlocal includeexpr=substitute(v:fname,'^\\/','','') |
 "        \ setlocal path+=./;/
-"   if system("uname -m") == "arm64"
+"   if trim(system("uname -m")) == "arm64"
 "     autocmd FileType php setlocal path+=/opt/homebrew/share/pear
 "   else
 "     autocmd FileType php setlocal path+=/usr/local/share/pear

--- a/.vim/rc/fzf.rc.vim
+++ b/.vim/rc/fzf.rc.vim
@@ -141,7 +141,7 @@ function! s:fzf_statusline()
 endfunction
 
 autocmd! User FzfStatusLine call <SID>fzf_statusline()
-if system("uname -m") == "arm64"
+if trim(system("uname -m")) == "arm64"
   set rtp+=/opt/homebrew/opt/fzf
 else
   set rtp+=/usr/local/opt/fzf

--- a/.vim/rc/init.rc.vim
+++ b/.vim/rc/init.rc.vim
@@ -7,7 +7,7 @@ endfunction
 function! IsMac() abort
   return !s:is_windows && !has('win32unix')
       \ && (has('mac') || has('macunix') || has('gui_macvim')
-      \     || (!executable('xdg-open') && system('uname') =~? '^darwin'))
+      \     || (!executable('xdg-open') && trim(system('uname')) =~? '^darwin'))
 endfunction
 
 " Use English interface.

--- a/.vim/rc/plug.rc.vim
+++ b/.vim/rc/plug.rc.vim
@@ -36,7 +36,7 @@ if has('vim_starting')
     Plug 'kana/vim-submode'
     Plug 'easymotion/vim-easymotion'
     Plug 'pbrisbin/vim-mkdir'
-    if system("uname -m") == "arm64"
+    if trim(system("uname -m")) == "arm64"
       Plug '/opt/homebrew/opt/fzf'
     else
       Plug '/usr/local/opt/fzf'

--- a/.vim/rc/unix.rc.vim
+++ b/.vim/rc/unix.rc.vim
@@ -1,6 +1,6 @@
 set shell=zsh
 
-if system("uname -m") == "arm64"
+if trim(system("uname -m")) == "arm64"
   let $PATH = expand('~/bin').':/opt/homebrew/bin/:'.$PATH
 else
   let $PATH = expand('~/bin').':/usr/local/bin/:'.$PATH


### PR DESCRIPTION
The result of `system('uname -m')` command have a trailing newline, maybe.
This commit to remove white spaces from the result of command, aims to ensure to identify the machine architecture.

I have referred to these pages.
- https://github.com/vim/vim/issues/2767#issuecomment-377781026
- https://vi.stackexchange.com/a/26557