### PR TITLE
Never used "Synergy" and "ShareMouse" on my macOS

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -399,8 +399,6 @@ else
   brew install --cask notion
   brew install --cask kindle
   brew install --cask microsoft-teams
-  brew install --cask synergy
-  brew install --cask sharemouse
   brew install --cask alacritty
   brew install --cask session-manager-plugin
   brew install --cask microsoft-edge


### PR DESCRIPTION
And "Synergy" was deleted from Homebrew Cask.
- https://github.com/Homebrew/homebrew-cask/pull/119496
- https://github.com/Homebrew/homebrew-cask/commit/0037f2409a6a16dee051d25ae19b2f7ece80b856

If I need to use the same functionality in the future, I would like to use "Universal Control".
- https://support.apple.com/en-us/HT212757