### PR TITLE
Use "HTTPS" protocol that cloning "Perl::Build" repository

### DIFF
--- a/bin/setup_perl.sh
+++ b/bin/setup_perl.sh
@@ -7,7 +7,7 @@ if [ ! -d $PLENV_PLUGINS_PATH ]; then
 fi
 PERL_BUILD_PATH="$PLENV_PLUGINS_PATH/perl-build"
 if [ ! -d $PERL_BUILD_PATH ]; then
-  git clone git://github.com/tokuhirom/Perl-Build.git $PERL_BUILD_PATH
+  git clone https://github.com/tokuhirom/Perl-Build.git $PERL_BUILD_PATH
 else
   cd $PERL_BUILD_PATH && git checkout master && git pull --rebase --prune
 fi


### PR DESCRIPTION
Prevent the error like this.
> fatal: remote error:
>   The unauthenticated git protocol on port 9418 is no longer supported.
> Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.