### PR TITLE
Use explicit context in "Starship" custom command config

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -324,5 +324,5 @@ style = "yellow"
 [zig]
 style = "yellow"
 
-[custom]
+[custom.none]
 style = "green"


### PR DESCRIPTION
Without explicit context, the warning is now displayed when loading the config.
This commit prevents the warning.

```
[WARN] - (starship::config): Failed to load config value: invalid type: string "green", expected struct CustomConfig
```

The context seems to be required with this change, maybe.
- https://github.com/starship/starship/pull/3829

Refs.
- https://starship.rs/config/#custom-commands

Examples of custom modules are:
- https://github.com/starship/starship/discussions/1252