### PR TITLE
Open a file in "insert mode" with Visual Studio Code's Neovim extension

### DIFF
--- a/.vim/rc/im-select.rc.vim
+++ b/.vim/rc/im-select.rc.vim
@@ -13,4 +13,5 @@ endfunction
 augroup im_select
   autocmd!
   autocmd BufNew,BufEnter,InsertLeave * call MakeInputSourceToEnglish()
+  autocmd BufNew,BufEnter * startinsert
 augroup END


### PR DESCRIPTION
It aims to prevent unintentional overwriting in Japanese input.
Although the Esc key must be entered first to use Vim's cursor movement, the benefits outweigh the hassle.

I have the impression that by setting the file to insert mode when it is opened, a Neovim buffer seems to be created, which reduces the fidgetiness of the operation.
The insert mode when a file is opened is close to the default setting of Visual Studio Code, and the usability seems to be a combination of the best parts of Visual Studio Code and Neovim.

`startinsert` reference is:
- https://vim-jp.org/vimdoc-ja/insert.html#:startinsert