### PR TITLE
Use `helm` instead of deprecated `kubernetes-helm`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -198,7 +198,7 @@ brew install protobuf
 brew install pv
 brew install git-secrets
 brew install testssl
-brew install kubernetes-helm
+brew install helm
 brew install gradle
 brew install azure-cli
 brew install circleci


### PR DESCRIPTION
Warning was:
```
Warning: Use helm instead of deprecated kubernetes-helm
```

The result of each `brew info` command.
```
$ brew info kubernetes-helm

Warning: Use helm instead of deprecated kubernetes-helm
helm: stable 3.8.2 (bottled), HEAD
Kubernetes package manager
https://helm.sh/
/opt/homebrew/Cellar/helm/3.8.2 (64 files, 46.1MB) *
  Poured from bottle on 2022-04-16 at 21:45:15
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/helm.rb
License: Apache-2.0
==> Dependencies
Build: go ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Analytics
install: 52,596 (30 days), 143,468 (90 days), 524,569 (365 days)
install-on-request: 51,391 (30 days), 140,025 (90 days), 512,971 (365 days)
build-error: 9 (30 days)
```

```
$ brew info helm

helm: stable 3.8.2 (bottled), HEAD
Kubernetes package manager
https://helm.sh/
/opt/homebrew/Cellar/helm/3.8.2 (64 files, 46.1MB) *
  Poured from bottle on 2022-04-16 at 21:45:15
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/helm.rb
License: Apache-2.0
==> Dependencies
Build: go ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Analytics
install: 52,596 (30 days), 143,468 (90 days), 524,569 (365 days)
install-on-request: 51,391 (30 days), 140,025 (90 days), 512,971 (365 days)
build-error: 9 (30 days)
```