### PR TITLE
Use "GNU gdb" with only "x86_64"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -76,7 +76,9 @@ brew install wdiff
 brew install wget
 brew install bash
 brew install emacs
-brew install gdb
+if [ "$(uname -m)" = "x86_64" ]; then
+  brew install gdb
+fi
 brew install gpatch
 brew install less
 brew install m4


### PR DESCRIPTION
It seems to be only available in "x86_64" version.

Error on "arm64" was:
```
gdb: The x86_64 architecture is required for this software.
Error: gdb: An unsatisfied requirement failed this build.
```

See also:
- https://formulae.brew.sh/formula/gdb
- https://doesitarm.com/formula/gdb/
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96168

```
$ gcc --version

Apple clang version 13.1.6 (clang-1316.0.21.2)
Target: arm64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```