### PR TITLE
Introduce "Xcodes.app" instead of `xcodes`  CLI

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -413,6 +413,7 @@ else
   brew install --cask warp
   brew install --cask cloudflare-warp
   brew install --cask hyper
+  brew install --cask xcodes
 
   brew install --cask font-fira-code
   brew install --cask font-fira-code-nerd-font


### PR DESCRIPTION
When I try to install using the `brew install xcodes` command, I get an error that there is no `xctest` command and cannot install.

```
$ brew install xcodes

Running `brew update --preinstall`...
Warning: Treating xcodes as a formula. For the cask, use homebrew/cask/xcodes
==> Cloning https://github.com/RobotsAndPencils/xcodes.git
Cloning into '/Users/machupicchubeta/Library/Caches/Homebrew/xcodes--git'...
==> Checking out tag 0.20.0
HEAD is now at bfefa45 Bump version to 0.20.0
==> Installing xcodes from robotsandpencils/made
Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Preferences or run:
  softwareupdate --all --install --force

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 13.3.

==> make install prefix=/opt/homebrew/Cellar/xcodes/0.20.0
Last 15 lines from /Users/machupicchubeta/Library/Logs/Homebrew/xcodes/01.make:
2022-05-07 14:53:40 +0000

make
install
prefix=/opt/homebrew/Cellar/xcodes/0.20.0

error: terminated(72): /usr/bin/xcrun --sdk macosx --find xctest output:
    xcrun: error: unable to find utility "xctest", not a developer tool or in PATH

make: *** [xcodes] Error 1

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/robotsandpencils/homebrew-made/issues

Error: A newer Command Line Tools release is available.
Update them from Software Update in System Preferences or run:
  softwareupdate --all --install --force

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 13.3.
```

It seems that the `xcode-select --install` command does not install the `xctest` command.

As far as I can remember, the `xcodes` CLI has never been used before, so it is removed from brewfile.sh and "Xcodes.app" is installed instead.
It should also be noted that "Xcodes.app" does not require compilation and does not require "Xcode.app" or `xctest` command, making it easy to install.

See also:
- https://github.com/RobotsAndPencils/xcodes
- https://github.com/RobotsAndPencils/XcodesApp