### PR TITLE
Remove tools that had combined with "docker-sync"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -40,7 +40,6 @@ brew tap github/gh
 brew tap mongodb/brew
 brew tap clementtsang/bottom
 brew tap elastic/tap
-brew tap eugenmayer/dockersync
 brew tap spectralops/tap
 brew tap warrensbox/tap
 brew tap auth0/auth0-cli
@@ -260,9 +259,6 @@ brew install sleuthkit
 brew install robotsandpencils/made/xcodes
 brew install libressl
 brew install graphicsmagick
-brew install unox
-brew install fswatch
-brew install unison
 brew install shared-mime-info
 brew install graphviz
 brew install teller


### PR DESCRIPTION
Remove the tools -- "unox", "fswatch", "unison" -- that had combined with "docker-sync" since I'v no longer used "docker-sync".

See also:
- https://github.com/machupicchubeta/dotfiles/commit/29be86dec48e34dedc51d331ef9b49b160bcc54d
- https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html#advanced-optional
- https://github.com/EugenMayer/docker-sync
- https://docker-sync.readthedocs.io/en/latest/

This commit essentially reverts the commit.
- https://github.com/machupicchubeta/dotfiles/commit/fcdbdc183ef08f41f11566d6b6361ffcf9be1c6a