### PR TITLE
Remove "kite"

### DIFF
--- a/.vim/rc/kite.rc.vim
+++ b/.vim/rc/kite.rc.vim
@@ -1,7 +1,0 @@
-let g:kite_supported_languages = ['*']
-let g:kite_tab_complete = 1
-set completeopt += preview
-autocmd CompleteDone * if !pumvisible() | pclose | endif
-set belloff += ctrlg
-set statusline = %<%f\ %h%m%r%{kite#statusline()}%=%-14.(%l,%c%V%)\ %P
-set laststatus = 2

--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -383,7 +383,6 @@ else
   brew install --cask osquery
   brew install --cask lens
   brew install --cask framer
-  brew install --cask kite
   brew install --cask deepl
   brew install --cask marvel
   brew install --cask brave-browser


### PR DESCRIPTION
It is not currently available for download, so the Cask has been removed also.

- https://www.kite.com/kite-is-temporarily-unavailable/?source=download
> Kite is temporarily unavailable

See also:
- https://github.com/Homebrew/homebrew-cask/commit/d35a90bdf0b7ddfe290d132766c9fafcfc6795f4
- https://github.com/Homebrew/homebrew-cask/pull/123507