### PR TITLE
(Re)install "CommandLineTools" only when "usr/bin" and "SDKs" directories do not exist

### DIFF
--- a/bin/setup_command_line_tools.sh
+++ b/bin/setup_command_line_tools.sh
@@ -2,6 +2,12 @@
 set -eu
 
 COMMAND_LINE_TOOLS_PATH='/Library/Developer/CommandLineTools'
+
+if [ -d "$COMMAND_LINE_TOOLS_PATH/usr/bin" -a -d "$COMMAND_LINE_TOOLS_PATH/SDKs" ]; then
+  echo -e "Skip the (re)installation of CommandLineTools.\nSince usr/bin and SDKs directories exist under $COMMAND_LINE_TOOLS_PATH, (re)installation is unlikely to be necessary.\nIf you are forced to re-install, remove those directories before executing the command."
+  exit 0
+fi
+
 sudo rm -rf "$COMMAND_LINE_TOOLS_PATH"
 xcode-select --install > /dev/null 2>&1
 sleep 1


### PR DESCRIPTION
If "usr/bin" and "SDKs" directories exist under "/Library/Developer/CommandLineTools" directory, it seems to have been successfully installed in many cases.
Since those directories often disappeared after upgrading macOS, I had a policy of reinstalling them every time.
However, the situation has changed recently, and it seems that it is acceptable to judge by the presence or absence of those directories.

See also:
- https://github.com/machupicchubeta/dotfiles/commit/bd478b40f3840e7b1d48cbd24023c753b5bfbe7c