### PR TITLE
Make sure to initialize programming environment tools at shell startup

### DIFF
--- a/.bash/hooks.sh
+++ b/.bash/hooks.sh
@@ -1,9 +1,3 @@
-if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi
-if which plenv > /dev/null; then eval "$(plenv init -)"; fi
-if which pyenv > /dev/null; then eval "$(pyenv init --path)"; fi
-if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
-if which goenv > /dev/null; then eval "$(goenv init -)"; fi
-if which jenv > /dev/null; then eval "$(jenv init -)"; fi
 if which direnv > /dev/null; then eval "$(direnv hook bash)"; fi
 if which starship > /dev/null; then eval "$(starship init bash)"; fi
 

--- a/.bash/programming_environments
+++ b/.bash/programming_environments
@@ -1,0 +1,6 @@
+if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi
+if which plenv > /dev/null; then eval "$(plenv init -)"; fi
+if which pyenv > /dev/null; then eval "$(pyenv init --path)"; fi
+if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
+if which goenv > /dev/null; then eval "$(goenv init -)"; fi
+if which jenv > /dev/null; then eval "$(jenv init -)"; fi

--- a/.zsh/hooks.zsh
+++ b/.zsh/hooks.zsh
@@ -1,9 +1,3 @@
-if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi
-if which plenv > /dev/null; then eval "$(plenv init -)"; fi
-if which pyenv > /dev/null; then eval "$(pyenv init --path)"; fi
-if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
-if which goenv > /dev/null; then eval "$(goenv init -)"; fi
-if which jenv > /dev/null; then eval "$(jenv init -)"; fi
 if which direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
 if which starship > /dev/null; then eval "$(starship init zsh)"; fi
 

--- a/.zsh/programming_environments
+++ b/.zsh/programming_environments
@@ -1,0 +1,6 @@
+if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi
+if which plenv > /dev/null; then eval "$(plenv init -)"; fi
+if which pyenv > /dev/null; then eval "$(pyenv init --path)"; fi
+if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
+if which goenv > /dev/null; then eval "$(goenv init -)"; fi
+if which jenv > /dev/null; then eval "$(jenv init -)"; fi

--- a/config/sheldon_bash/plugins.toml
+++ b/config/sheldon_bash/plugins.toml
@@ -5,3 +5,21 @@ apply = ["source"]
 local = "~/.bash"
 use = ["*.sh"]
 apply = ["source"]
+
+[plugins.rbenv]
+inline = 'if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi'
+
+[plugins.plenv]
+inline = 'if which plenv > /dev/null; then eval "$(plenv init -)"; fi'
+
+[plugins.pyenv]
+inline = 'if which pyenv > /dev/null; then eval "$(pyenv init --path)"; fi'
+
+[plugins.nodenv]
+inline = 'if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi'
+
+[plugins.goenv]
+inline = 'if which goenv > /dev/null; then eval "$(goenv init -)"; fi'
+
+[plugins.jenv]
+inline = 'if which jenv > /dev/null; then eval "$(jenv init -)"; fi'

--- a/config/sheldon_zsh/plugins.toml
+++ b/config/sheldon_zsh/plugins.toml
@@ -43,3 +43,21 @@ use = ["redis-cli/_redis-cli"]
 local = "~/.zsh"
 use = ["*.zsh"]
 apply = ["source"]
+
+[plugins.rbenv]
+inline = 'if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi'
+
+[plugins.plenv]
+inline = 'if which plenv > /dev/null; then eval "$(plenv init -)"; fi'
+
+[plugins.pyenv]
+inline = 'if which pyenv > /dev/null; then eval "$(pyenv init --path)"; fi'
+
+[plugins.nodenv]
+inline = 'if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi'
+
+[plugins.goenv]
+inline = 'if which goenv > /dev/null; then eval "$(goenv init -)"; fi'
+
+[plugins.jenv]
+inline = 'if which jenv > /dev/null; then eval "$(jenv init -)"; fi'


### PR DESCRIPTION
I remember that when I first started using "sheldon", the Programming environment tools were initialized at shell startup. Umm ....
But I recently noticed that they were not initialized and not added to the `PATH` environment variable, so that only the commands installed by "Homebrew" could be found.
This was very inconvenient.

This commit will ensure that the programming environment tools are initialized via "sheldon".
It will now switch to the programming language version specified in the `.xxx-version` file.