### PR TITLE
Install Go language server `gopls`

### DIFF
--- a/bin/setup_go.sh
+++ b/bin/setup_go.sh
@@ -9,3 +9,4 @@ goenv rehash
 eval "$(goenv init -)"
 
 go install github.com/fujimura/git-gsub@latest
+go install golang.org/x/tools/gopls@latest


### PR DESCRIPTION
After I had installed the "Go" extension in "Visual Studio Code", I get the "gopls" install dialog every time I launch it.
I would prefer to install it via the "Go" setup script rather than the GUI.

Refs.
- https://pkg.go.dev/golang.org/x/tools/gopls#section-readme
- https://github.com/golang/tools/tree/master/gopls
- https://code.visualstudio.com/docs/languages/go
- https://microsoft.github.io/language-server-protocol/