### PR TITLE
Follow template changes in Sheldon

### DIFF
--- a/config/sheldon_zsh/plugins.toml
+++ b/config/sheldon_zsh/plugins.toml
@@ -6,7 +6,7 @@ github = "romkatv/zsh-defer"
 apply = ["source"]
 
 [templates]
-defer = { value = 'zsh-defer source "{{ file }}"', each = true }
+defer = "{% for file in files %}zsh-defer source \"{{ file }}\"\n{% endfor %}"
 
 [plugins.compinit]
 inline = 'autoload -Uz compinit && zsh-defer compinit && compinit'


### PR DESCRIPTION
The template engine was changed in version 0.7.0, and removed the "each" field from the template configuration. I rewrote it referring to the example.

See also:
- https://github.com/rossmacarthur/sheldon/commit/708bd9e3337f107410f977618dc47d6824191a16
- https://github.com/rossmacarthur/sheldon/commit/c2127c39f4d131f255f45dda289f496c07272bec
- https://github.com/rossmacarthur/sheldon/blob/trunk/RELEASES.md#070
- https://sheldon.cli.rs/Examples.html