### PR TITLE
Remove "Lacona"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -355,7 +355,6 @@ else
   brew install --cask vlc
   brew install --cask chrome-remote-desktop-host
   brew install --cask vivaldi
-  brew install --cask lacona
   brew install --cask wireshark
   brew install --cask sketch
   brew install --cask blisk


### PR DESCRIPTION
It is not currently available for download, so the Cask has been removed also.

See also:

- https://github.com/Homebrew/homebrew-cask/pull/135985
- https://github.com/Homebrew/homebrew-cask/commit/cc9366f475d22719aeb0c6caf1b8c448c8e6396f

> lacona.io is no longer up, and v2 is only via MAS or Setapp.

- https://lacona.app/faq

> While Lacona 2 has many improvements over Lacona 1, there are a few features that haven’t yet made the jump. If this is breaking your workflow, you can download Lacona 1 here. Note that Lacona 1 is no longer being developed or supported, and it may break at any time!