### PR TITLE
Use aliases with "Oh My Zsh" `docker` plugin

### DIFF
--- a/config/sheldon_zsh/plugins.toml
+++ b/config/sheldon_zsh/plugins.toml
@@ -26,13 +26,8 @@ apply = ["source"]
 [plugins.ohmyzsh-plugins]
 github = "ohmyzsh/ohmyzsh"
 dir = "plugins"
-use = ["{bundler/bundler,docker-compose/docker-compose,git/git,history/history,macos/macos,terraform/terraform,z/z}.plugin.zsh"]
+use = ["{bundler/bundler,docker/docker,docker-compose/docker-compose,git/git,history/history,macos/macos,terraform/terraform,z/z}.plugin.zsh"]
 apply = ["source"]
-
-[plugins.ohmyzsh-plugin-docker]
-github = "ohmyzsh/ohmyzsh"
-dir = "plugins"
-use = ["docker/_docker"]
 
 [plugins.ohmyzsh-plugin-redis-cli]
 github = "ohmyzsh/ohmyzsh"


### PR DESCRIPTION
The aliases has been added to "Oh My Zsh" `docker` plugin. So, this commit configures to use it.

See also:
- https://github.com/ohmyzsh/ohmyzsh/commit/c6f0504cf0f75bc17cc422e82fdb84f0c994c461
- https://github.com/ohmyzsh/ohmyzsh/pull/6527