### PR TITLE
Prefer to use `ED25519` algorithm to generate a new SSH key

### DIFF
--- a/bin/generate_key_pair.sh
+++ b/bin/generate_key_pair.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -eu
 
-if [ ! -e "$HOME/.ssh/id_rsa" ]; then
+ALGORITHM="ed25519"
+
+if [ ! -e "$HOME/.ssh/id_$ALGORITHM" ]; then
   echo 'Enter email:'
   read -r email
-  ssh-keygen -t rsa -b 4096 -C "$email"
+  ssh-keygen -t "$ALGORITHM" -C "$email"
   eval "$(ssh-agent -s)"
-  ssh-add -K "$HOME/.ssh/id_rsa"
+  ssh-add -K "$HOME/.ssh/id_$ALGORITHM"
 fi


### PR DESCRIPTION
The `ED25519` algorithm is recommended on the GitHub and GitLab docs because it is more secure than `RSA`.

See also
- https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
- https://docs.gitlab.com/ee/user/ssh.html
- https://en.wikipedia.org/wiki/EdDSA