### PR TITLE
Prevent warnings about the `-K` and `-A` options of the `ssh-add` command

### DIFF
--- a/.bash/hooks.sh
+++ b/.bash/hooks.sh
@@ -30,4 +30,4 @@ complete -C aws_completer aws
 
 complete -C $HOMEBREW_PREFIX/bin/terraform terraform
 
-ssh-add -A &> /dev/null
+ssh-add --apple-load-keychain &> /dev/null

--- a/.zsh/ssh.zsh
+++ b/.zsh/ssh.zsh
@@ -1,1 +1,1 @@
-ssh-add -A &> /dev/null
+ssh-add --apple-load-keychain &> /dev/null

--- a/bin/generate_key_pair.sh
+++ b/bin/generate_key_pair.sh
@@ -8,5 +8,5 @@ if [ ! -e "$HOME/.ssh/id_$ALGORITHM" ]; then
   read -r email
   ssh-keygen -t "$ALGORITHM" -C "$email"
   eval "$(ssh-agent -s)"
-  ssh-add -K "$HOME/.ssh/id_$ALGORITHM"
+  ssh-add --apple-use-keychain "$HOME/.ssh/id_$ALGORITHM"
 fi


### PR DESCRIPTION
The warnings were:
```
WARNING: The -K and -A flags are deprecated and have been replaced
         by the --apple-use-keychain and --apple-load-keychain
         flags, respectively.  To suppress this warning, set the
         environment variable APPLE_SSH_ADD_BEHAVIOR as described in
         the ssh-add(1) manual page.
```