### PR TITLE
Define a keymap in Vim to add a blank line above and below the cursor

### DIFF
--- a/.vim/rc/mappings.rc.vim
+++ b/.vim/rc/mappings.rc.vim
@@ -324,7 +324,14 @@ function! StripWhitespace ()
   call setreg('/', old_query)
 endfunction
 noremap <leader>ss :call StripWhitespace ()<CR>
+" }}}
+
+" Enter blank line {{{
 noremap <CR> o<ESC>
+inoremap <S-CR> <End><CR>
+inoremap <C-S-CR> <Home><CR><Up>
+nnoremap <S-CR> mzo<ESC>`z
+nnoremap <C-S-CR> mzO<ESC>`z
 " }}}
 
 " move between tabs key map {{{


### PR DESCRIPTION
I referred to this page.
- https://qiita.com/itmammoth/items/312246b4b7688875d023#%EF%BC%94%E4%B8%8A%E4%B8%8B%E3%81%AB%E7%A9%BA%E8%A1%8C%E3%82%92%E6%8C%BF%E5%85%A5%E3%81%99%E3%82%8B