### PR TITLE
Stop using TypeProf as a Ruby LSP (Language Server Protocol) in Vim/Neovim

### DIFF
--- a/.vim/rc/lsp.rc.vim
+++ b/.vim/rc/lsp.rc.vim
@@ -6,3 +6,4 @@ let g:asyncomplete_auto_popup = 1
 let g:asyncomplete_auto_completeopt = 0
 let g:asyncomplete_popup_delay = 200
 let g:lsp_text_edit_enabled = 0
+let g:lsp_settings = { 'typeprof': { 'disabled': 1 } }


### PR DESCRIPTION
Maybe I don't have a good development environment at hand, when I open a Ruby file, the TypeProf warning becomes noise, making it difficult to write.
Until I can set up my development environment, I will disable TypeProf as LSP when editing Ruby files with Vim/Neovim.