### PR TITLE
Introduce GitLab command-line tool `glab`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -296,6 +296,7 @@ brew install terraform-lsp
 brew install sheldon
 brew install neo-cowsay
 brew install neovide
+brew install glab
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info glab

==> glab: stable 1.24.1 (bottled), HEAD
Open-source GitLab command-line tool
https://gitlab.com/gitlab-org/cli
Not installed
From:
https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/glab.rb
License: MIT
==> Dependencies
Build: go ✔
==> Options
--HEAD
  Install HEAD version
  ==> Analytics
  install: 2,062 (30 days), 6,603 (90 days), 11,548 (365 days)
  install-on-request: 2,056 (30 days), 6,586 (90 days), 11,527 (365
  days)
  build-error: 1 (30 days)
```