### PR TITLE
No need to leave environment variables used temporarily in setup scripts

### DIFF
--- a/.zsh/hooks.zsh
+++ b/.zsh/hooks.zsh
@@ -21,3 +21,6 @@ if [ -r "$GITHUB_REPOSITORIES_PATH/seebi/dircolors-solarized" ]; then eval $(gdi
 complete -o nospace -C $HOMEBREW_PREFIX/bin/terraform terraform
 
 preexec() { print '' }
+
+unset GITHUB_REPOSITORIES_PATH
+unset REPOSITORIES_PATH

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -52,12 +52,8 @@ export AWS_PROFILE=default
 export DISABLE_SPRING=1
 
 export XDG_CONFIG_HOME="$HOME/.config"
-export REPOSITORIES_PATH="$HOME/Repositories"
-export GHQ_ROOT="$REPOSITORIES_PATH"
-export GITHUB_REPOSITORIES_PATH="$REPOSITORIES_PATH/github.com"
-export SETTINGS_PATH="$GITHUB_REPOSITORIES_PATH/$(whoami)/dotfiles"
-export BIN_PATH="$HOME/bin"
 export RBENV_ROOT="$HOME/.rbenv"
+export GHQ_ROOT="$HOME/Repositories"
 
 export PYTHONPATH=$(if [ -d "$PYENV_ROOT/shims" ]; then echo "$PYENV_ROOT/shims"; elif [ -d "$HOMEBREW_PREFIX/opt/python/libexec/bin" ]; then echo "$HOMEBREW_PREFIX/opt/python/libexec/bin"; else echo '/usr/bin/python'; fi)
 

--- a/bin/download_settings.sh
+++ b/bin/download_settings.sh
@@ -31,3 +31,5 @@ if [ ! -x "$(command -v gh)" ]; then
 fi
 
 gh auth login --web
+
+unset REPOSITORIES_PATH

--- a/bin/put_scripts.sh
+++ b/bin/put_scripts.sh
@@ -34,3 +34,8 @@ fi
 if [ -f "$GITHUB_REPOSITORIES_PATH/machupicchubeta/diceware/diceware.wordlist.asc" ]; then
   ln -s "$GITHUB_REPOSITORIES_PATH/machupicchubeta/diceware/diceware.wordlist.asc" "$BIN_PATH/diceware.wordlist.asc"
 fi
+
+unset SETTINGS_PATH
+unset GITHUB_REPOSITORIES_PATH
+unset REPOSITORIES_PATH
+unset BIN_PATH

--- a/bin/put_settings.sh
+++ b/bin/put_settings.sh
@@ -107,3 +107,7 @@ fi
 if [ -f "$SETTINGS_PATH/rbenv/default-gems" ]; then
   ln -s "$SETTINGS_PATH/rbenv/default-gems" "$RBENV_ROOT/default-gems"
 fi
+
+unset SETTINGS_PATH
+unset GITHUB_REPOSITORIES_PATH
+unset REPOSITORIES_PATH

--- a/bin/setup_hyper.sh
+++ b/bin/setup_hyper.sh
@@ -22,3 +22,7 @@ for config_directory in "${CONFIG_DIRECTORIES[@]}"; do
     ln -s "$SETTINGS_PATH/hyper/.hyper.js" "$config_directory/.hyper.js"
   fi
 done
+
+unset SETTINGS_PATH
+unset GITHUB_REPOSITORIES_PATH
+unset REPOSITORIES_PATH


### PR DESCRIPTION
There is no problem with leaving it as it is, but I think it is better to remove it. Besides, when the directory name is displayed in the tab of iTerm2, the environment variable mentioned above is displayed and bothers me, so I want to remove it.