### PR TITLE
Introduce "flyctl"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -297,6 +297,7 @@ brew install sheldon
 brew install neo-cowsay
 brew install neovide
 brew install glab
+brew install flyctl
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info flyctl

==> flyctl: stable 0.0.549 (bottled), HEAD
Command-line tools for fly.io services
https://fly.io
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/flyctl.rb
License: Apache-2.0
==> Dependencies
Build: go ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 155 (30 days), 10,763 (90 days), 94,545 (365 days)
install-on-request: 153 (30 days), 10,760 (90 days), 94,545 (365 days)
build-error: 2 (30 days)
```