### PR TITLE
Do not prompt for confirmation in the script that removes docker resources

### DIFF
--- a/bin/docker_prune.sh
+++ b/bin/docker_prune.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -eu
 
-docker system prune --all
-docker system prune --volumes
-docker builder prune --all
-docker container prune
+docker system prune --all --force
+docker system prune --volumes --force
+docker builder prune --all --force
+docker container prune --force
 if [ $(docker container ls --all --quiet | wc -l) -gt 0 ]; then
   docker container stop $(docker container ls --all --quiet)
   docker container rm --volumes $(docker container ls --all --quiet)
 fi
-docker image prune --all
-docker volume prune
-docker network prune
+docker image prune --all --force
+docker volume prune --force
+docker network prune --force


### PR DESCRIPTION
I type "y" every time I get a confirmation prompt. I don't feel the need to display the confirmation prompt because I never have a chance to type "n".