### PR TITLE
Correct a garbled lambda character on Starship "success_symbol" variable

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -85,7 +85,7 @@ style = "yellow"
 discharging_symbol = "⚠️ "
 
 [character]
-success_symbol = "[ﬦ ➜](bold green)"
+success_symbol = "[λ ➜](bold green)"
 error_symbol = "[∅ ✗](bold red)"
 vicmd_symbol = "[ ➜](bold green) "
 


### PR DESCRIPTION
I have Starship "success_symbol" variable set to a lambda character. I will use Starship's Haskell symbol because the characters were garbled somehow.

https://github.com/starship/starship/blob/5e5727ff68bc282b5b44a9fcdc929326c0e999d5/docs/config/README.md?plain=1#L2083