### PR TITLE
Avoid the read error in `gdircolors` in Bash also

### DIFF
--- a/.bash/hooks.sh
+++ b/.bash/hooks.sh
@@ -14,7 +14,7 @@ if [ -r "$HOMEBREW_PREFIX/opt/fzf/shell/key-bindings.bash" ]; then source "$HOME
 : "${REPOSITORIES_PATH:=$HOME/Repositories}"
 : "${GITHUB_REPOSITORIES_PATH=$REPOSITORIES_PATH/github.com}"
 
-eval $(gdircolors "$GITHUB_REPOSITORIES_PATH/seebi/dircolors-solarized")
+eval $(gdircolors "$GITHUB_REPOSITORIES_PATH/seebi/dircolors-solarized/dircolors.ansi-universal")
 
 # Case-insensitive globbing (used in pathname expansion)
 shopt -s nocaseglob


### PR DESCRIPTION
See also:
- https://github.com/machupicchubeta/dotfiles/commit/aad769597b6f02233ff29e96cbf9e58445abcbf5
- https://github.com/machupicchubeta/dotfiles/pull/405