### PR TITLE
Show Zsh completions with the same color settings as `LS_COLORS`

### DIFF
--- a/.zsh/completions.zsh
+++ b/.zsh/completions.zsh
@@ -22,7 +22,11 @@ zle -N predict-off
 zstyle ':predict' verbose true
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z} r:|[-_.]=**'
 zstyle ':completion:*' completer _complete _ignored _cmdstring _canonical_paths _expand _extensions _external_pwds _expand_alias _files _multi_parts
-zstyle ':completion:*' list-colors ''
+if [ -n "$LS_COLORS" ]; then
+  zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
+else
+  zstyle ':completion:*' list-colors ''
+fi
 zstyle ':completion:*:cd:*' tag-order local-directories path-directories
 zstyle ':completion:*' ignore-parents parent pwd ..
 zstyle ':completion:*:sudo:*' command-path $HOMEBREW_PREFIX/sbin $HOMEBREW_PREFIX/bin /usr/sbin /usr/bin /sbin /bin /usr/X11R6/bin


### PR DESCRIPTION
I'll try to set it up following this article.
- https://qiita.com/yuyuchu3333/items/84fa4e051c3325098be3#zsh%E3%81%AE%E8%A3%9C%E5%AE%8C%E3%81%AB%E3%82%82%E5%90%8C%E3%81%98%E8%89%B2%E3%82%92%E8%A8%AD%E5%AE%9A