### PR TITLE
Goodbye "PhantomJS"; Thank you for everything

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -367,7 +367,6 @@ else
   brew install --cask dotnet-sdk
   brew install --cask visual-studio-code
   brew install --cask dynamodb-local
-  brew install --cask phantomjs
   brew install --cask discord
   brew install --cask aerial
   brew install --cask figma


### PR DESCRIPTION
I was running the machine setup commands and looking at the output when I noticed that "PhantomJS" was still there. I haven't used it in years.

I curious about its current state, I visited to the "PhantomJS" repository and found that it had been public archived and made read-only at the end of last month. So I decided I had to remove it from my setup commands as well.

- https://phantomjs.org/
- https://formulae.brew.sh/cask/phantomjs

> phantomjs has been officially discontinued upstream.
> It may stop working correctly (or at all) in recent versions of macOS.

- https://github.com/ariya/phantomjs/issues/15344