### PR TITLE
Introduce "FFmpeg"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -297,6 +297,7 @@ brew install neo-cowsay
 brew install neovide
 brew install glab
 brew install flyctl
+brew install ffmpeg
 
 # For Ruby
 brew install openssl


### PR DESCRIPTION
```
$ brew info ffmpeg

==> ffmpeg: stable 6.0 (bottled), HEAD
Play, record, convert, and stream audio and video
https://ffmpeg.org/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/ffmpeg.rb
License: GPL-2.0-or-later
==> Dependencies
Build: pkg-config ✔
Required: aom ✔, aribb24 ✔, dav1d ✔, fontconfig ✔, freetype ✔, frei0r ✔, gnutls ✔, lame ✔, libass ✔, libbluray ✔, librist ✔, libsoxr ✔, libvidstab ✔, libvmaf ✔, libvorbis ✔, libvpx ✔, opencore-amr ✔, openjpeg ✔, opus ✔, rav1e ✔, rubberband ✔, sdl2 ✔, snappy ✔, speex ✔, srt ✔, svt-av1 ✔, tesseract ✔, theora ✔, webp ✔, x264 ✔, x265 ✔, xvid ✔, xz ✔, zeromq ✔, zimg ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 72,989 (30 days), 8,626 (90 days), 1,546,169 (365 days)
install-on-request: 43,807 (30 days), 7,494 (90 days), 1,343,277 (365 days)
build-error: 68 (30 days)
```