### PR TITLE
Correct "plugin name" in "Sheldon" configuration

### DIFF
--- a/config/sheldon_bash/plugins.toml
+++ b/config/sheldon_bash/plugins.toml
@@ -6,7 +6,7 @@ local = "~/.bash"
 use = ["*.sh"]
 apply = ["source"]
 
-[plugins.dotfiles.private]
+[plugins.dotfiles-private]
 local = "~/.bash.private"
 use = ["*.sh"]
 apply = ["source"]

--- a/config/sheldon_zsh/plugins.toml
+++ b/config/sheldon_zsh/plugins.toml
@@ -39,7 +39,7 @@ local = "~/.zsh"
 use = ["*.zsh"]
 apply = ["source"]
 
-[plugins.dotfiles.private]
+[plugins.dotfiles-private]
 local = "~/.zsh.private"
 use = ["*.zsh"]
 apply = ["source"]


### PR DESCRIPTION
It seems that "." is not available in the "plugin name" in Sheldon's configuration file. Replace it with "-".

- https://sheldon.cli.rs/Configuration.html