### PR TITLE
Set environment variables related to Homebrew

### DIFF
--- a/.bash/variables.sh
+++ b/.bash/variables.sh
@@ -1,11 +1,13 @@
 if [ "$(uname -m)" = "x86_64" ]; then
   export ARCHFLAGS="-arch x86_64"
   export HOMEBREW_PREFIX="/usr/local"
+  export HOMEBREW_CELLAR="/usr/local/Cellar"
   export HOMEBREW_REPOSITORY="/usr/local/Homebrew"
   export BUNDLE_USER_HOME="$HOME/.bundle_x86_64"
 elif [ "$(uname -m)" = "arm64" ]; then
   export ARCHFLAGS="-arch arm64"
   export HOMEBREW_PREFIX="/opt/homebrew"
+  export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
   export HOMEBREW_REPOSITORY="/opt/homebrew"
   export BUNDLE_USER_HOME="$HOME/.bundle_arm64"
 fi
@@ -27,8 +29,8 @@ export PATH="$HOMEBREW_PREFIX/opt/libxml2/bin:$HOMEBREW_PREFIX/opt/libxslt/bin:$
 if [ -n "$(echo $CPU_BRAND | grep -o 'Apple')" -a "$(uname -m)" = "arm64" ]; then
   export PATH="$PATH:/usr/local/bin"
 fi
-: "${MANPATH:=}"
-export MANPATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnuman:$HOMEBREW_PREFIX/opt/erlang/lib/erlang/man:$HOMEBREW_PREFIX/man:$MANPATH"
+export MANPATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnuman:$HOMEBREW_PREFIX/opt/erlang/lib/erlang/man:$HOMEBREW_PREFIX/share/man${MANPATH+:$MANPATH}"
+export INFOPATH="$HOMEBREW_PREFIX/share/info:${INFOPATH:-}"
 
 # Larger bash history (allow 2^10^2 entries; default is 500)
 export HISTSIZE=1048576

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -1,11 +1,13 @@
 if [ "$(uname -m)" = "x86_64" ]; then
   export ARCHFLAGS="-arch x86_64"
   export HOMEBREW_PREFIX="/usr/local"
+  export HOMEBREW_CELLAR="/usr/local/Cellar"
   export HOMEBREW_REPOSITORY="/usr/local/Homebrew"
   export BUNDLE_USER_HOME="$HOME/.bundle_x86_64"
 elif [ "$(uname -m)" = "arm64" ]; then
   export ARCHFLAGS="-arch arm64"
   export HOMEBREW_PREFIX="/opt/homebrew"
+  export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
   export HOMEBREW_REPOSITORY="/opt/homebrew"
   export BUNDLE_USER_HOME="$HOME/.bundle_arm64"
 fi
@@ -30,8 +32,8 @@ export PATH="$HOMEBREW_PREFIX/opt/libxml2/bin:$HOMEBREW_PREFIX/opt/libxslt/bin:$
 if [ -n "$(echo $CPU_BRAND | grep -o 'Apple')" -a "$(uname -m)" = "arm64" ]; then
   export PATH="$PATH:/usr/local/bin"
 fi
-: "${MANPATH:=}"
-export MANPATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnuman:$HOMEBREW_PREFIX/opt/erlang/lib/erlang/man:$HOMEBREW_PREFIX/man:$MANPATH"
+export MANPATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnuman:$HOMEBREW_PREFIX/opt/erlang/lib/erlang/man:$HOMEBREW_PREFIX/share/man${MANPATH+:$MANPATH}"
+export INFOPATH="$HOMEBREW_PREFIX/share/info:${INFOPATH:-}"
 
 # Larger bash history (allow 2^10^2 entries; default is 500)
 export HISTSIZE=1048576


### PR DESCRIPTION
Set environment variables with the equivalent of the command displayed after Homebrew installation.

```
==> Next steps:
- Run these two commands in your terminal to add Homebrew to your PATH:
    (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> /Users/machupicchubeta/.zprofile
    eval "$(/opt/homebrew/bin/brew shellenv)"
- Run brew help to get started
- Further documentation:
    https://docs.brew.sh
```

```
$ brew shellenv

export HOMEBREW_PREFIX="/opt/homebrew";
export HOMEBREW_CELLAR="/opt/homebrew/Cellar";
export HOMEBREW_REPOSITORY="/opt/homebrew";
export PATH="/opt/homebrew/bin:/opt/homebrew/sbin${PATH+:$PATH}";
export MANPATH="/opt/homebrew/share/man${MANPATH+:$MANPATH}:";
export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}";
```