### PR TITLE
Use the arm64 version of the "Slate" app instead of the x86_64 version

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -338,7 +338,6 @@ else
   brew install --cask sublime-text
   brew install --cask encryptme
   brew install --cask karabiner-elements
-  brew install --cask slate
   brew install --cask dash
   brew install --cask reflector
   brew install --cask disk-inventory-x
@@ -445,6 +444,8 @@ if [ "$(uname -m)" = "x86_64" ]; then
 
   brew cu virtualbox --cleanup
   brew cu soundflower --cleanup
+elif [ "$(uname -m)" = "arm64" ]; then
+  brew install --cask fertigt-slate
 fi
 
 brew cleanup --prune=0 -s


### PR DESCRIPTION
The x86_64 version of the app was no longer maintained and had been removed from the Homebrew Cask.
- https://github.com/Homebrew/homebrew-cask/pull/127817
- https://github.com/Homebrew/homebrew-cask/commit/ec3cbf2aed7e311ec8357b7442351df3f0466f84

```
$ brew info --cask slate

==> slate: 1.0.25
https://github.com/jigish/slate
/opt/homebrew/Caskroom/slate/1.0.25 (119B)
==> Name
Slate
==> Description
Window management application
==> Artifacts
Slate.app (App)
```

There was an arm64 version of the app, so I tried using that.
- https://github.com/fertigt/slate_arm64

```
$ brew info --cask fertigt-slate

==> fertigt-slate: 1.0
https://github.com/fertigt/slate_arm64
Not installed
From:
https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/fertigt-slate.rb
==> Name
Slate (arm64)
==> Description
Window management application
==> Artifacts
Slate.app (App)
==> Analytics
install: 0 (30 days), 0 (90 days), 0 (365 days)
```

Perhaps I may consider switching to other window management apps in the future.
- https://github.com/rxhanson/Rectangle
  - https://rectangleapp.com/
- https://github.com/kasper/phoenix
- https://github.com/ianyh/Amethyst
  - https://ianyh.com/amethyst/