### PR TITLE
Stop installing Elasticsearch and Kibana using Homebrew

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -39,7 +39,6 @@ brew tap heroku/brew
 brew tap github/gh
 brew tap mongodb/brew
 brew tap clementtsang/bottom
-brew tap elastic/tap
 brew tap spectralops/tap
 brew tap warrensbox/tap
 brew tap auth0/auth0-cli
@@ -250,8 +249,6 @@ brew install procs
 brew install sd
 brew install lazydocker
 brew install lazygit
-brew install elasticsearch-full
-brew install kibana-full
 brew install openjdk
 brew install sleuthkit
 brew install robotsandpencils/made/xcodes


### PR DESCRIPTION
The documentation for elastic up to 7.17 described how to install using Homebrew, but the latest version of the documentation only describes how to install on bare metal, how to use Docker, and how to use the Elastic Stack on Kubernetes.

Elasticsearch, Kibana 7.17 Documentation
- https://www.elastic.co/guide/en/elasticsearch/reference/7.17/brew.html
- https://www.elastic.co/guide/en/kibana/7.17/brew.html

Documentation for Elasticsearch, Kibana 8.8 (currently the latest version)
- https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html
  - https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html
- https://www.elastic.co/guide/en/kibana/current/install.html
  - https://www.elastic.co/guide/en/kibana/current/docker.html

The Homebrew formulae by elastic have not been maintained for over a year and the latest version cannot be installed.
- https://github.com/elastic/homebrew-tap/tags

Releases Page for Elasticsearch and Kibana
- https://github.com/elastic/elasticsearch/releases
- https://github.com/elastic/kibana/releases