### PR TITLE
Enable to run `brew untap` for taps they no longer need

### DIFF
--- a/bin/brew_untap_core_and_cask.sh
+++ b/bin/brew_untap_core_and_cask.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -u
+
+brew untap homebrew/core
+brew untap homebrew/cask
+
+brew cleanup --debug --verbose


### PR DESCRIPTION
- https://brew.sh/2023/02/16/homebrew-4.0.0/

> Using JSON files downloaded from formulae.brew.sh for package installation rather than local homebrew/core and homebrew/cask taps.

> This is now the default behaviour so the HOMEBREW_INSTALL_FROM_API variable has been removed and is a no-op.

  - https://github.com/Homebrew/brew/pull/14412

- https://brew.sh/2023/07/20/homebrew-4.1.0/

> We’ve made many improvements around the new 4.0.0 feature of using JSON files downloaded from formulae.brew.sh for package installation rather than local homebrew/core and homebrew/cask taps.

I noticed a significant change in Homebrew 4.0.0 and 4.1.0 by the Nudging message when running the brew command.
- https://github.com/Homebrew/brew/commit/b64ed9dc587d3b541cdc29e997ba4eccd3a95e77

And the `brew cleanup` command is based on this Issue.
- https://github.com/Homebrew/brew/issues/15674#issuecomment-1634300555