### PR TITLE
Stop using deprecated commands in the Solargraph gem

### DIFF
--- a/bin/setup_ruby.sh
+++ b/bin/setup_ruby.sh
@@ -14,6 +14,3 @@ eval "$(rbenv init -)"
 gem update --system
 gem update
 gem cleanup
-
-latest_solargraph_core_version=$(solargraph available-cores | grep --perl-regexp '^(\d+\.\d+)\.\d+$' | head -n 1)
-solargraph download-core $latest_solargraph_core_version


### PR DESCRIPTION
The message was:
```
The `download-core` command is deprecated.
Current versions of Solargraph use RBS for core and stdlib documentation.
```

See also:
- https://github.com/castwide/solargraph/commit/cf1cd663077317c6402fa9450f24596ed6596cdd
- https://github.com/castwide/solargraph/releases/tag/v0.49.0
- https://github.com/castwide/solargraph/blob/c8d40adc997efc90eff1892a0e161543a696d358/CHANGELOG.md