### PR TITLE
Make easier to see that Google Cloud icons displayed in Starship by opening spacing

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -69,7 +69,6 @@ symbol = "☁️   "
 format = 'on [$symbol($profile )(\($region\) )]($style)'
 style = "dimmed yellow"
 
-
 [battery]
 full_symbol = "🔋 "
 charging_symbol = "⚡️ "

--- a/config/starship.toml
+++ b/config/starship.toml
@@ -135,7 +135,7 @@ style = "dimmed white"
 style = "red"
 
 [gcloud]
-symbol = "☁️ 🇬️ "
+symbol = "☁️  🇬️ "
 style = "dimmed blue"
 
 [git_branch]


### PR DESCRIPTION
First, try spacing them out.