### PR TITLE
Use the current latest version of PostgreSQL 16

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -150,7 +150,7 @@ brew install packer
 brew install packer-completion
 brew install chrome-cli
 brew install cscope
-brew install postgresql
+brew install postgresql@16
 brew install parallel
 brew install nmap
 brew install go


### PR DESCRIPTION
In the Homebrew Core Repository, PostgreSQL was to be versioned formulae.
I didn't notice that PostgreSQL had not been upgraded since PostgreSQL 14 because I did not specify the version explicitly.

See also:
- https://github.com/Homebrew/homebrew-core/pull/107726