### PR TITLE
Use "eza" instead of "exa"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -242,7 +242,7 @@ brew install tldr
 brew install fd
 brew install ripgrep
 brew install rga
-brew install exa
+brew install eza
 brew install bat
 brew install git-delta
 brew install procs


### PR DESCRIPTION
See also:
- https://github.com/ogham/exa/commit/fb05c421ae98e076989eb6e8b1bcf42c07c1d0fe

> exa is unmaintained, use the [fork eza](https://github.com/eza-community/eza) instead.

```
$ brew info eza

==> eza: stable 0.14.1 (bottled)
Modern, maintained replacement for ls
https://github.com/eza-community/eza
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/e/eza.rb
License: MIT
==> Dependencies
Build: pandoc ✘, pkg-config ✔, rust ✔
Required: libgit2 ✔
==> Analytics
install: 5,692 (30 days), 6,504 (90 days), 6,505 (365 days)
install-on-request: 5,695 (30 days), 6,505 (90 days), 6,507 (365 days)
build-error: 5 (30 days)
```