### PR TITLE
Remove "Packer"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -146,8 +146,6 @@ brew install docutils
 brew install universal-ctags --HEAD
 brew link universal-ctags
 brew install tree
-brew install packer
-brew install packer-completion
 brew install chrome-cli
 brew install cscope
 brew install postgresql@16


### PR DESCRIPTION
Packer has been deprecated in the Homebrew Core Repository due to the change to a non-open-source license.

See also:
- https://github.com/Homebrew/homebrew-core/commit/421d661ef9a1db98a55c560184853967877edaba