### PR TITLE
Remove "Vault"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -155,7 +155,6 @@ brew install go
 brew install goenv --HEAD
 brew install slackcat
 brew install lame
-brew install vault
 brew install yank
 brew install v8
 brew install git-secrets


### PR DESCRIPTION
Vault has been deprecated in the Homebrew Core Repository due to the change to a non-open-source license.

See also:
- https://github.com/Homebrew/homebrew-core/commit/4b72b4f10f0d413fb54980bb536dc34e76951bf0