### PR TITLE
Remove "SSH Permit A38"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -201,7 +201,6 @@ brew install circleci
 brew install eslint
 brew install iso-codes
 brew install ssh-copy-id
-brew install ssh-permit-a38
 brew install swiftformat
 brew install terraform_landscape
 brew install thors-serializer


### PR DESCRIPTION
It seems like no longer maintained.

See also:
- https://github.com/Homebrew/homebrew-core/commit/e102ed87ee1589858a5a1258636e71ff5545991f
- https://github.com/Homebrew/homebrew-core/pull/120366