### PR TITLE
No need to install Bundler gem separately

### DIFF
--- a/rbenv/default-gems
+++ b/rbenv/default-gems
@@ -1,4 +1,3 @@
-bundler
 tmuxinator
 git-browse-remote
 gem-browse


### PR DESCRIPTION
Since Ruby 2.6, Bundler has been installed by default as the default gem.

Refs.
- https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

> Bundler is now installed as a default gem.

- https://bundler.io/

> Any modern distribution of Ruby comes with Bundler preinstalled by default.