### PR TITLE
Introduce "pinentry-mac"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -136,6 +136,7 @@ brew install spark
 brew install tmux
 brew install reattach-to-user-namespace
 brew install gnupg
+brew install pinentry-mac
 brew install grc
 brew install tor
 brew install nkf


### PR DESCRIPTION
```
$ brew info pinentry-mac

==> pinentry-mac: stable 1.1.1.1 (bottled), HEAD
Pinentry for GPG on Mac
https://github.com/GPGTools/pinentry
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/p/pinentry-mac.rb
License: GPL-2.0-or-later and GPL-3.0-or-later
==> Dependencies
Build: autoconf ✔, automake ✔, libtool ✔, texinfo ✘
Required: gettext ✔, libassuan ✔
==> Requirements
Build: Xcode (on macOS) ✔
Required: macOS ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
You can now set this as your pinentry program like

~/.gnupg/gpg-agent.conf
    pinentry-program /opt/homebrew/bin/pinentry-mac
==> Analytics
install: 1,965 (30 days), 5,398 (90 days), 11,874 (365 days)
install-on-request: 1,880 (30 days), 5,209 (90 days), 11,574 (365 days)
build-error: 0 (30 days)
```