### PR TITLE
Move the user section of git config to private settings

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -113,9 +113,6 @@
   pushInsteadOf = "git://gist.github.com/"
 [url "git://gist.github.com/"]
   insteadOf = "gist:"
-[user]
-  name = machupicchubeta
-  email = machupicchubeta@gmail.com
 [pull]
   rebase = true
 [push]


### PR DESCRIPTION
There is no need to hide it, but I think it will be easier to reuse the machine global git configs by moving it to private settings.