### PR TITLE
Set `GPG_TTY`

### DIFF
--- a/.bash/variables.sh
+++ b/.bash/variables.sh
@@ -66,3 +66,5 @@ export GUILE_TLS_CERTIFICATE_DIRECTORY="$HOMEBREW_PREFIX/etc/gnutls/"
 export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl@1.1"
 
 export STARSHIP_CONFIG="$XDG_CONFIG_HOME/starship/config.toml"
+
+export GPG_TTY=$(tty)

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -75,3 +75,5 @@ export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl@1.1"
 export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#F2E6D4,bg=#7E87D6,bold,underline"
 
 export STARSHIP_CONFIG="$XDG_CONFIG_HOME/starship/config.toml"
+
+export GPG_TTY=$(tty)


### PR DESCRIPTION
Refs.
- https://wiki.archlinux.org/title/GnuPG#Configure_pinentry_to_use_the_correct_TTY
- https://wiki.archlinux.jp/index.php/GnuPG#.E9.81.A9.E5.88.87.E3.81.AA_TTY_.E3.82.92.E4.BD.BF.E3.81.86.E3.82.88.E3.81.86.E3.81.AB_pinentry_.E3.82.92.E8.A8.AD.E5.AE.9A
- https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-gpg-key