### PR TITLE
Use absolute line numbers in (neo)vim

### DIFF
--- a/.vim/rc/view.rc.vim
+++ b/.vim/rc/view.rc.vim
@@ -209,10 +209,10 @@ set ruler
 set showmode
 
 " Use relative line numbers
-if exists("&relativenumber")
- set relativenumber
- au BufReadPost * set relativenumber
-endif
+" if exists("&relativenumber")
+"  set relativenumber
+"  au BufReadPost * set relativenumber
+" endif
 
 " Start scrolling three lines before the horizontal window border
 set scrolloff=3


### PR DESCRIPTION
Sometimes it is useful to display relative line numbers for line jumping, but I never had a problem without them. Rather, I experienced more use cases where I needed to know the absolute line number, for example, when pair programming.

I have a shortcut key that toggles the display of relative and absolute line numbers, so I feel it is more useful to remember the existence of this key.

https://github.com/machupicchubeta/dotfiles/blob/e48a4fa6d59b7b01ed7a62a51985ee87c164c197/.vim/rc/mappings.rc.vim#L66-L67