### PR TITLE
Remove "Gitter"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -404,7 +404,6 @@ else
   brew install --cask wireshark
   brew install --cask sketch
   brew install --cask blisk
-  brew install --cask gitter
   brew install --cask fliqlo
   brew install --cask google-earth-pro
   brew install --cask zoom


### PR DESCRIPTION
It was removed from the Homebrew Cask in February of this year.

See also:
- https://github.com/Homebrew/homebrew-cask/pull/141757
- https://blog.gitter.im/2023/02/13/gitter-has-fully-migrated-to-matrix/
- https://gitter.im/