### PR TITLE
Introduce "Tree-sitter"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -163,6 +163,7 @@ brew install v8
 brew install vite
 brew install esbuild
 brew install terraform-lsp
+brew install tree-sitter
 
 # Libraries used in Nokogiri gem
 brew install libxml2


### PR DESCRIPTION
```
$ brew info tree-sitter

==> tree-sitter: stable 0.20.8 (bottled), HEAD
Parser generator tool and incremental parsing library
https://tree-sitter.github.io/
/opt/homebrew/Cellar/tree-sitter/0.20.8 (18 files, 12.3MB) *
  Poured from bottle using the formulae.brew.sh API on 2023-11-05 at 14:09:03
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/tree-sitter.rb
License: MIT
==> Dependencies
Build: emscripten ✘, node ✔, rust ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 10,550 (30 days), 37,060 (90 days), 99,578 (365 days)
install-on-request: 353 (30 days), 1,084 (90 days), 5,603 (365 days)
build-error: 2 (30 days)
```

- https://github.com/tree-sitter/tree-sitter