### PR TITLE
Introduce "Silicon"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -288,6 +288,7 @@ brew install choose-rust
 brew install jless
 brew install neo-cowsay
 brew install sd
+brew install silicon
 
 # File management tools
 brew install tree


### PR DESCRIPTION
```
$ brew info silicon

Warning: Treating silicon as a formula. For the cask, use homebrew/cask/silicon
==> silicon: stable 0.5.1 (bottled)
Create beautiful image of your source code
https://github.com/Aloxaf/silicon/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/s/silicon.rb
License: MIT
==> Dependencies
Build: rust ✔
Required: harfbuzz ✔
==> Analytics
install: 79 (30 days), 233 (90 days), 502 (365 days)
install-on-request: 79 (30 days), 233 (90 days), 502 (365 days)
build-error: 0 (30 days)
```