### PR TITLE
Set up a `git push` to the upstream branch of the same name

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -116,7 +116,8 @@
 [pull]
   rebase = true
 [push]
-  default = simple
+  default = upstream
+  autoSetupRemote = true
 [filter "media"]
   required = true
   clean = git media clean %f


### PR DESCRIPTION
Using a simple central workflow that assumes all branches have the same name on the remote.

Refs.
- https://git-scm.com/docs/git-config#Documentation/git-config.txt-pushautoSetupRemote
- https://git-scm.com/docs/git-config#Documentation/git-config.txt-pushdefault