### PR TITLE
Configure `tig`

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -122,9 +122,6 @@
   required = true
   clean = git media clean %f
   smudge = git media smudge %f
-[tig "bind"]
-  generic = g move-first-line
-  generic = G move-last-line
 [rerere]
   autoupdated = 1
   enabled = 1

--- a/config/tig/config
+++ b/config/tig/config
@@ -1,0 +1,1 @@
+bind main Y !@bash -c "echo -n %(commit) | pbcopy"


### PR DESCRIPTION
Refs.
- https://jonas.github.io/tig/doc/tigrc.5.html

I deleted the tig settings written in the git config file and created a new configuration file under XDG Base Directory.
Then, I added keybinding for easy copying of a commit ID.