### PR TITLE
Drop `bundle --path` config

### DIFF
--- a/config/bundle/arm64/config
+++ b/config/bundle/arm64/config
@@ -1,6 +1,5 @@
 ---
 BUNDLE_BUILD__NOKOGIRI: "--use-system-libraries=true --with-xml2-include=/opt/homebrew/opt/libxml2/include/libxml2"
 BUNDLE_JOBS: "7"
-BUNDLE_PATH: "vendor/bundle"
 BUNDLE_BUILD__MYSQL2: "--with-opt-dir=/opt/homebrew/opt/openssl@3"
 BUNDLE_BUILD__PUMA: "--with-cflags=-Wno-error=implicit-function-declaration"

--- a/config/bundle/x86_64/config
+++ b/config/bundle/x86_64/config
@@ -1,6 +1,5 @@
 ---
 BUNDLE_BUILD__NOKOGIRI: "--use-system-libraries=true --with-xml2-include=/usr/local/opt/libxml2/include/libxml2"
 BUNDLE_JOBS: "7"
-BUNDLE_PATH: "vendor/bundle"
 BUNDLE_BUILD__MYSQL2: "--with-opt-dir=/usr/local/opt/openssl@3"
 BUNDLE_BUILD__PUMA: "--with-cflags=-Wno-error=implicit-function-declaration"


### PR DESCRIPTION
I didn't think I would have any trouble switching the Ruby gems installation path for each project. From now on, I will try to install and run Ruby gems on a system global basis.

Refs.
- https://bundler.io/v1.12/man/bundle-config.1.html

See also:
- https://qiita.com/jnchito/items/99b1dbea1767a5095d85