### PR TITLE
Install Apple Fonts via Homebrew

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -480,6 +480,11 @@ else
   brew install --cask font-anonymice-nerd-font
   brew install --cask font-agave-nerd-font
   brew install --cask font-3270-nerd-font
+  brew install --cask font-sf-mono
+  brew install --cask font-sf-pro
+  brew install --cask font-sf-compact
+  brew install --cask font-new-york
+  brew install --cask font-sf-mono-for-powerline
 
   brew cu --all --cleanup --yes
 fi

--- a/bin/setup_fonts.sh
+++ b/bin/setup_fonts.sh
@@ -3,17 +3,6 @@ set -eu
 
 USER_FONT_DIR="$HOME/Library/Fonts/"
 
-echo -e "\nCopy SFMono fonts to the user font directory"
-TERMINAL_APP_PATH=""
-if [ -d "/System/Applications/Utilities/Terminal.app" ]; then
-  TERMINAL_APP_PATH="/System/Applications/Utilities/Terminal.app"
-elif [ -d "/Applications/Utilities/Terminal.app" ]; then
-  TERMINAL_APP_PATH="/Applications/Utilities/Terminal.app"
-fi
-if [ -n "$TERMINAL_APP_PATH" ]; then
-  cp -f "$TERMINAL_APP_PATH"/Contents/Resources/Fonts/*.otf "$USER_FONT_DIR"
-fi
-
 echo -e "\nInstall \"Source Han Code JP\" to the user font directory"
 curl -fsSL https://github.com/adobe-fonts/source-han-code-jp/archive/refs/tags/2.012R.tar.gz | tar -xzC /tmp/
 SOURCE_HAN_CODE_JP_TEMP_DIR="/tmp/source-han-code-jp-2.012R"
@@ -22,3 +11,6 @@ if [ -d "$SOURCE_HAN_CODE_JP_TEMP_DIR" ]; then
   find "$SOURCE_HAN_CODE_JP_TEMP_DIR" -type f -name '*.ttc' -or -name '*.otf' -exec mv --target-directory="$USER_FONT_DIR" {} +
   rm --recursive --force "$SOURCE_HAN_CODE_JP_TEMP_DIR"
 fi
+
+unset SOURCE_HAN_CODE_JP_TEMP_DIR
+unset USER_FONT_DIR


### PR DESCRIPTION
Apple Fonts are now available for download and can be easily installed via homebrew-cask-fonts.

Refs.
- https://developer.apple.com/fonts/
- https://github.com/Homebrew/homebrew-cask-fonts