### PR TITLE
Use ruby-lsp gem instead of solargraph

### DIFF
--- a/config/rtx/ruby/default-gems
+++ b/config/rtx/ruby/default-gems
@@ -11,4 +11,4 @@ lolcat
 powder
 reek
 neovim
-solargraph
+ruby-lsp


### PR DESCRIPTION
"Ruby LSP" seems to be more actively maintained.

Refs.
- https://github.com/Shopify/ruby-lsp

> The Ruby LSP is an implementation of the language server protocol for Ruby, used to improve rich features in editors. It is a part of a wider goal to provide a state-of-the-art experience to Ruby developers using modern standards for cross-editor features, documentation and debugging.