### PR TITLE
Use "zsh-autosuggestions" default style

### DIFF
--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -101,6 +101,4 @@ export GUILE_TLS_CERTIFICATE_DIRECTORY="$HOMEBREW_PREFIX/etc/gnutls/"
 export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/opt/openssl@3/lib/pkgconfig"
 export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl@3 --with-libyaml-dir=$HOMEBREW_PREFIX/opt/libyaml --with-libffi-dir=$HOMEBREW_PREFIX/opt/libffi --with-readline-dir=$HOMEBREW_PREFIX/opt/readline --with-gmp-dir=$HOMEBREW_PREFIX/opt/gmp  --enable-yjit"
 
-export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#F2E6D4,bg=#7E87D6,bold,underline"
-
 export GPG_TTY=$(tty)


### PR DESCRIPTION
In particular, the background color set in custom style remained after the command was selected, making it difficult to see.
By using the default style settings, the background color is no longer bothersome.

Refs.
- https://github.com/zsh-users/zsh-autosuggestions?tab=readme-ov-file#configuration