### PR TITLE
Organize gitignore

### DIFF
--- a/.bash/variables.sh
+++ b/.bash/variables.sh
@@ -32,6 +32,7 @@ export MANPAGER="less -X"
 
 export LESS='-R'
 export LESSOPEN="| $HOMEBREW_PREFIX/bin/src-hilite-lesspipe.sh %s"
+export LESSHISTFILE="$XDG_DATA_HOME/less/history"
 
 # Prefer US English and use UTF-8
 export LC_ALL=en_US.UTF-8

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.vim/.netrwhist
+.vim/autoload/*
+.vim/backups/*
+.vim/colors/*
+.vim/pack/*
+.vim/plugged/*
+.vim/swaps/*
+.vim/tags
+.vim/undo/*

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -35,6 +35,7 @@ export MANPAGER="less -X"
 
 export LESS='-R'
 export LESSOPEN="| $HOMEBREW_PREFIX/bin/src-hilite-lesspipe.sh %s"
+export LESSHISTFILE="$XDG_DATA_HOME/less/history"
 
 # Prefer US English and use UTF-8
 export LC_ALL=en_US.UTF-8

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -8,7 +8,6 @@ dist
 tags
 tags.lock
 temp
-vendor/bundle/**
 
 !**/.keep
 !.bundle/config

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -3,7 +3,6 @@
 .DS_Store
 .bundle/*
 .envrc
-.lesshst
 dist
 tags
 tags.lock

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -4,15 +4,6 @@
 .bundle/*
 .envrc
 .lesshst
-.vim/.netrwhist
-.vim/autoload/*
-.vim/backups/*
-.vim/colors/*
-.vim/pack/*
-.vim/plugged/*
-.vim/swaps/*
-.vim/tags
-.vim/undo/*
 dist
 tags
 tags.lock


### PR DESCRIPTION
* Separate the contents of gitignore into system global and repository-specific
* No need to gitignore 'vendor/bundle/**'
    * I already removed `bundle --path` config
    * https://github.com/machupicchubeta/dotfiles/commit/27b5d5f509fbd5a0aeab772ecb8614219b36ec28
* No need to gitignore '.lesshst'
    * `less` supports XDG Base Directory
    * https://wiki.archlinux.org/title/XDG_Base_Directory#Supported
    * https://github.com/gwsw/less/issues/153
    * https://www.greenwoodsoftware.com/less/news.590.html
    * https://www.greenwoodsoftware.com/less/news.600.html