### PR TITLE
Install the latest version of Node.js as well as the lts version on the system global

### DIFF
--- a/bin/setup_nodejs.sh
+++ b/bin/setup_nodejs.sh
@@ -6,7 +6,7 @@ mise install node@lts
 mise upgrade node@lts
 mise install node@latest
 mise upgrade node@latest
-mise use --global node@latest
+mise use --global node@latest node@lts
 mise prune node
 mise reshim
 

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,7 +1,7 @@
 [tools]
 go = "latest"
 java = "latest"
-node = "latest"
+node = ["latest", "lts"]
 perl = "latest"
 python = "latest"
 ruby = "latest"


### PR DESCRIPTION
Previously, the lts version had not been set as a system global and was targeted for removal by the `mise prune` command. This eliminates that hassle.