### PR TITLE
Avoid the error when ".zcompdump" file is missing

### DIFF
--- a/config/sheldon/zsh/plugins.toml
+++ b/config/sheldon/zsh/plugins.toml
@@ -3,14 +3,18 @@ apply = ["source"]
 
 [plugins.compinit]
 inline = '''
-local now=$(date +"%s")
-local updated=$(date -r $HOME/.zcompdump +"%s")
-local threshold=$((60 * 60 * 24))
-if [ $((${now} - ${updated})) -gt ${threshold} ]; then
+if [ ! -f $HOME/.zcompdump ]; then
   autoload -Uz compinit && compinit
 else
-  # if there are new functions can be omitted by giving the option -C.
-  autoload -Uz compinit && compinit -C
+  local now=$(date +"%s")
+  local updated=$(date -r $HOME/.zcompdump +"%s")
+  local threshold=$((60 * 60 * 24))
+  if [ ! -f $HOME/.zcompdump || $((${now} - ${updated})) -gt ${threshold} ]; then
+    autoload -Uz compinit && compinit
+  else
+    # if there are new functions can be omitted by giving the option -C.
+    autoload -Uz compinit && compinit -C
+  fi
 fi
 '''
 


### PR DESCRIPTION
The error was:
```
usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]
            [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[mm]dd]HH]MM[[cc]yy][.SS] | new_date] [+output_fmt]
(eval):[:4: ']' expected
(eval):4: bad math expression: operand expected at end of string
complete:13: command not found: compdef
```