### PR TITLE
Remove "navigator.lua" Neovim plugin 

### DIFF
--- a/config/nvim/lua/plugins/library.lua
+++ b/config/nvim/lua/plugins/library.lua
@@ -8,12 +8,5 @@ return {
     'MunifTanjim/nui.nvim',
     lazy = true,
     event = 'VeryLazy'
-  },
-  {
-    'ray-x/guihua.lua',
-    cond = (not vim.g.vscode),
-    lazy = true,
-    build = 'cd lua/fzy && make',
-    event = 'VeryLazy'
   }
 }

--- a/config/nvim/lua/plugins/lsp.lua
+++ b/config/nvim/lua/plugins/lsp.lua
@@ -133,16 +133,6 @@ return {
     event = 'VeryLazy'
   },
   {
-    'ray-x/navigator.lua',
-    cond = (not vim.g.vscode),
-    lazy = true,
-    opts = {},
-    event = 'VeryLazy',
-    dependencies = {
-      'ray-x/guihua.lua'
-    }
-  },
-  {
     'j-hui/fidget.nvim',
     cond = (not vim.g.vscode),
     lazy = true,

--- a/config/nvim/lua/plugins/suggestion.lua
+++ b/config/nvim/lua/plugins/suggestion.lua
@@ -40,7 +40,6 @@ return {
           { name = 'omni' },
           { name = 'nvim_lua' },
           { name = 'spell' },
-          { name = 'treesitter' },
           { name = 'cmdline' }
         }, {
           { name = 'buffer' }
@@ -95,11 +94,6 @@ return {
       vim.opt.spell = true
       vim.opt.spelllang = { 'en_us' }
     end,
-    event = 'VeryLazy'
-  },
-  {
-    'ray-x/cmp-treesitter',
-    lazy = true,
     event = 'VeryLazy'
   },
   {


### PR DESCRIPTION
That plugin seems overwrites the "nvim-lspconfig" settings unintentionally.

And remove Neovim plugins that do not seem to be used also.