### PR TITLE
Stop installing system-wide Python packages

### DIFF
--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -12,13 +12,3 @@ python3 -m pip install --upgrade pip
 pip3 install --upgrade setuptools wheel
 pip3 list --outdated | awk 'NR>2{print $1}' | xargs --no-run-if-empty pip3 install --upgrade
 pip3 install pynvim
-
-if [ "$(uname -m)" = "x86_64" ]; then
-  : "${HOMEBREW_PREFIX:=/usr/local}"
-elif [ "$(uname -m)" = "arm64" ]; then
-  : "${HOMEBREW_PREFIX:=/opt/homebrew}"
-fi
-
-if [ -x "$HOMEBREW_PREFIX/bin/pip3" ]; then
-  $HOMEBREW_PREFIX/bin/pip3 install pynvim
-fi


### PR DESCRIPTION
It will be followed PEP668.

- https://docs.brew.sh/Homebrew-and-Python#pep-668-python312-and-virtualenvs
- https://peps.python.org/pep-0668/#marking-an-interpreter-as-using-an-external-package-manager

Error was:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-brew-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.

    If you wish to install a non-brew packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```