### PR TITLE
Stop overwriting Ctrl-z Command in Neovim

### DIFF
--- a/config/nvim/lua/plugins/motion.lua
+++ b/config/nvim/lua/plugins/motion.lua
@@ -67,7 +67,7 @@ return {
     'stevearc/aerial.nvim',
     lazy = true,
     init = function()
-      vim.keymap.set('n', '<C-z>z', '<cmd>AerialToggle!<CR>')
+      vim.keymap.set('n', '<C-t>z', '<cmd>AerialToggle!<CR>')
     end,
     opts = {
       on_attach = function(bufnr)


### PR DESCRIPTION
Sometimes when I am writing code in Neovim, I want to use Terminal temporarily.
In such cases, the Ctrl-z command is used.