### PR TITLE
Introduce golang-migrate

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -159,6 +159,8 @@ brew install esbuild
 brew install terraform-lsp
 brew install tree-sitter
 
+brew install golang-migrate
+
 # Libraries used in Nokogiri gem
 brew install libxml2
 brew install libxslt


### PR DESCRIPTION
The tool is being used in a project in which I am currently participating.

```
$ brew info golang-migrate

==> golang-migrate: stable 4.17.0 (bottled)
Database migrations CLI tool
https://github.com/golang-migrate/migrate
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/golang-migrate.rb
License: MIT
==> Dependencies
Build: go ✔
==> Analytics
install: 1,262 (30 days), 4,553 (90 days), 15,440 (365 days)
install-on-request: 1,262 (30 days), 4,553 (90 days), 15,440 (365 days)
build-error: 0 (30 days)
```