### PR TITLE
Avoid installing libraries in system-wide Python

### DIFF
--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -10,5 +10,5 @@ mise reshim
 
 mise exec -- python3 -m pip install --upgrade pip
 mise exec -- pip3 install --upgrade setuptools wheel
-mise exec -- pip3 list --outdated | awk 'NR>2{print $1}' | xargs --no-run-if-empty pip3 install --upgrade
+mise exec -- pip3 list --outdated | awk 'NR>2{print $1}' | xargs --no-run-if-empty mise exec -- pip3 install --upgrade
 mise exec -- pip3 install pynvim


### PR DESCRIPTION
Use mise exec as in previous commits. I missed it at the time.
- https://github.com/machupicchubeta/dotfiles/commit/76c4d780c019109b243ebb69d41de98844fa90b4