### PR TITLE
Introduce golangci-lint

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -247,6 +247,7 @@ brew install ansible-lint
 brew install eslint
 brew install swiftformat
 brew install cfn-lint
+brew install golangci-lint
 
 # Command-line tools
 brew install jq


### PR DESCRIPTION
The tool is being used in a project in which I am currently participating.

```
$ brew info golangci-lint

==> golangci-lint: stable 1.56.2 (bottled), HEAD
Fast linters runner for Go
https://golangci-lint.run/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/golangci-lint.rb
License: GPL-3.0-only
==> Dependencies
Required: go ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 7,662 (30 days), 24,347 (90 days), 112,581 (365 days)
install-on-request: 7,657 (30 days), 24,334 (90 days), 112,535 (365 days)
build-error: 2 (30 days)
```