### PR TITLE
Remove the parallel_tests configuration file

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,3 +1,0 @@
---format progress
---format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log
-


### PR DESCRIPTION
I have not used that gem in recent years.