### PR TITLE
Make it easier to type code blocks in Markdown syntax

### DIFF
--- a/config/nvim/lua/plugins/code.lua
+++ b/config/nvim/lua/plugins/code.lua
@@ -20,7 +20,18 @@ return {
   {
     'windwp/nvim-autopairs',
     lazy = true,
-    opts = {},
+    config = function()
+      require('nvim-autopairs').setup({})
+
+      local rule = require('nvim-autopairs.rule')
+      local npairs = require('nvim-autopairs')
+      local cond = require('nvim-autopairs.conds')
+      npairs.add_rules({
+        rule('`', '`')
+          :with_move(cond.none())
+          :replace_map_cr(function() return '<C-g>u<CR><C-c>O' end)
+      })
+    end,
     event = 'VeryLazy'
   },
   {


### PR DESCRIPTION
- https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code

> To format code or text into its own distinct block, use triple backticks.