### PR TITLE
Remove "Kindle"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -432,7 +432,6 @@ else
   brew install --cask coscreen
   brew install --cask mmhmm
   brew install --cask notion
-  brew install --cask kindle
   brew install --cask microsoft-teams
   brew install --cask alacritty
   brew install --cask session-manager-plugin


### PR DESCRIPTION
- https://github.com/Homebrew/homebrew-cask/pull/160398
- https://github.com/Homebrew/homebrew-cask/pull/160186
> Kindle for Mac (now called the Kindle Classic app) has been replaced with a new app available from the App Store.

See also:
- https://www.amazon.com/kindle-dbs/arp/B0C9PRPV28