### PR TITLE
Follows renaming google-chrome-canary to google-chrome@canary

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -387,7 +387,7 @@ else
   brew install --cask githubpulse
   brew install --cask github
   brew install --cask paparazzi
-  brew install --cask google-chrome-canary
+  brew install --cask google-chrome@canary
   brew install --cask vlc
   brew install --cask chrome-remote-desktop-host
   brew install --cask vivaldi


### PR DESCRIPTION
```
$ brew info --cask google-chrome-canary

Warning: Cask homebrew/cask-versions/google-chrome-canary was renamed to google-chrome@canary.
==> google-chrome-canary: latest
https://www.google.com/chrome/canary/
Installed
/opt/homebrew/Caskroom/google-chrome-canary/latest (61.4KB)
==> Name
Google Chrome Canary
==> Description
Web browser
==> Artifacts
Google Chrome Canary.app (App)
```

Refs.
- https://github.com/Homebrew/homebrew-cask-versions/pull/20186
- https://github.com/Homebrew/homebrew-cask/pull/172349
- https://github.com/Homebrew/homebrew-cask/issues/112102