### PR TITLE
Remove "grammarly" cask

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -426,7 +426,6 @@ else
   brew install --cask alacritty
   brew install --cask session-manager-plugin
   brew install --cask microsoft-edge
-  brew install --cask grammarly
   brew install --cask raycast
   brew install --cask blackhole-2ch
   brew install --cask blackhole-16ch


### PR DESCRIPTION
The cask was disabled because it is discontinued upstream.

```
$ brew info --cask grammarly

==> grammarly: 1.5.81 (auto_updates)
https://www.grammarly.com/
Disabled because it is discontinued upstream!
Installed
/opt/homebrew/Caskroom/grammarly/1.5.81 (130B)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/g/grammarly.rb
==> Name
Grammarly
==> Description
Utility to fix grammar errors and style issues in text
==> Artifacts
Grammarly Editor.app (App)
==> Analytics
install: 222 (30 days), 799 (90 days), 3,033 (365 days)
```

Ref.
- https://github.com/Homebrew/homebrew-cask/pull/171625