### PR TITLE
Remove OpenSSL 1.1

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -49,7 +49,6 @@ brew upgrade --fetch-HEAD
 
 # Libraries that used in Ruby or so, or used to build from source code
 brew install openssl@3
-brew install openssl@1.1
 brew install readline
 brew install m4
 brew install autoconf


### PR DESCRIPTION
Refs.
- https://www.openssl.org/blog/blog/2023/09/11/eol-111/index.html

> OpenSSL 1.1.1 series has reached its End of Life (EOL). As such it will no longer receive publicly available security fixes.

```
$ brew info openssl@1.1

==> openssl@1.1: stable 1.1.1w (bottled) [keg-only]
Cryptography and SSL/TLS Toolkit
https://openssl.org/
Deprecated because it is not supported upstream!
Installed
/opt/homebrew/Cellar/openssl@1.1/1.1.1w (8,101 files, 18MB)
  Poured from bottle using the formulae.brew.sh API on 2024-04-30 at 03:06:23
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/o/openssl@1.1.rb
License: OpenSSL
==> Dependencies
Required: ca-certificates ✔
==> Caveats
A CA file has been bootstrapped using certificates from the system
keychain. To add additional certificates, place .pem files in
  /opt/homebrew/etc/openssl@1.1/certs

and run
  /opt/homebrew/opt/openssl@1.1/bin/c_rehash

openssl@1.1 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have openssl@1.1 first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/openssl@1.1/bin:$PATH"' >> ~/.zshrc

For compilers to find openssl@1.1 you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"

For pkg-config to find openssl@1.1 you may need to set:
  export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
==> Analytics
install: 36,099 (30 days), 114,740 (90 days), 1,496,585 (365 days)
install-on-request: 19,018 (30 days), 59,475 (90 days), 590,900 (365 days)
build-error: 22 (30 days)
```