### PR TITLE
Follows renaming firefox-developer-edition to firefox@developer-edition

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -361,7 +361,7 @@ else
   brew install --cask dropbox
   brew install --cask vagrant
   brew install --cask firefox
-  brew install --cask firefox-developer-edition
+  brew install --cask firefox@developer-edition
   brew install --cask evernote
   brew install --cask slack
   brew install --cask skitch


### PR DESCRIPTION
```
$ brew info --cask firefox-developer-edition

Warning: Cask homebrew/cask-versions/firefox-developer-edition was
renamed to firefox@developer-edition.
Error: Cask 'firefox-developer-edition' is unavailable: No Cask with
this name exists.
```

Refs.
- https://github.com/Homebrew/homebrew-cask/commit/34c9cd1149998376df6b20ad53ca3ba05d8fba00
- https://github.com/Homebrew/homebrew-cask/pull/172475
- https://github.com/Homebrew/homebrew-cask-versions/pull/20196