### PR TITLE
Untap "homebrew/cask-versions"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -28,7 +28,6 @@ mas install 1284863847 # Unsplash Wallpapers
 mas install 1295203466 # Microsoft Remote Desktop
 
 brew tap thoughtbot/formulae
-brew tap homebrew/cask-versions
 brew tap homebrew/services
 brew tap homebrew/bundle
 brew tap puma/puma


### PR DESCRIPTION
The repository has been archived by the owner on May 3, 2024.

Refs.
- https://github.com/Homebrew/homebrew-cask-versions/pull/20219