### PR TITLE
Untap `homebrew/cask-fonts`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -31,7 +31,6 @@ brew tap thoughtbot/formulae
 brew tap homebrew/services
 brew tap homebrew/bundle
 brew tap puma/puma
-brew tap homebrew/cask-fonts
 brew tap buo/cask-upgrade
 brew tap universal-ctags/universal-ctags
 brew tap heroku/brew


### PR DESCRIPTION
> This repository has been archived by the owner on May 16, 2024. It is now read-only.

It seems to be migrated fonts to `homebrew-cask`.