### PR TITLE
Introduce "ChatGPT"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -439,6 +439,7 @@ else
   brew install --cask wezterm
   brew install --cask temurin
   brew install --cask android-commandlinetools
+  brew install --cask chatgpt
 
   brew install --cask font-fira-code
   brew install --cask font-fira-code-nerd-font


### PR DESCRIPTION
```
$ brew info --cask chatgpt

==> chatgpt: 1.2024.134,1715807927 (auto_updates)
https://chatgpt.com/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/chatgpt.rb
==> Name
ChatGPT
==> Description
OpenAI's official ChatGPT desktop app
==> Artifacts
ChatGPT.app (App)
==> Analytics
install: 4,028 (30 days), 4,028 (90 days), 4,028 (365 days)
```