### PR TITLE
Introduct `act`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -225,6 +225,7 @@ brew install circleci
 brew install auth0
 brew install glab
 brew install flyctl
+brew install act
 
 # Linters and Code Formatters
 brew install swiftlint


### PR DESCRIPTION
Refs.
- https://github.com/nektos/act
- https://nektosact.com/

```
$ brew info act

==> act: stable 0.2.66 (bottled), HEAD
Run your GitHub Actions locally
https://github.com/nektos/act
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/a/act.rb
License: MIT
==> Dependencies
Build: go ✔
==> Options
--HEAD
        Install HEAD version
==> Analytics
install: 7,739 (30 days), 21,100 (90 days), 89,142 (365 days)
install-on-request: 7,739 (30 days), 21,101 (90 days), 89,142 (365 days)
build-error: 4 (30 days)
```
