### PR TITLE
Simplify setup scripts by using the asdf-flutter patch version

### DIFF
--- a/.bash/variables.sh
+++ b/.bash/variables.sh
@@ -61,9 +61,7 @@ export ASDF_FORCE_PREPEND="yes"
 export ASDF_PERL_DEFAULT_PACKAGES_FILE="$XDG_CONFIG_HOME/asdf/perl/default-perl-modules"
 export ASDF_HASHICORP_TERRAFORM_VERSION_FILE=".terraform-version"
 
-export FLUTTER_ROOT="$HOME/Repositories/github.com/flutter/flutter"
-
-export PATH="$HOMEBREW_PREFIX/opt/libxml2/bin:$HOMEBREW_PREFIX/opt/libxslt/bin:$HOMEBREW_PREFIX/opt/libiconv/bin:$HOMEBREW_PREFIX/opt/openssl@3/bin:$HOMEBREW_PREFIX/opt/bison/bin:$HOMEBREW_PREFIX/opt/libressl/bin:$HOMEBREW_PREFIX/opt/curl/bin:$HOMEBREW_PREFIX/opt/sqlite/bin:$HOMEBREW_PREFIX/opt/nss/bin:$HOMEBREW_PREFIX/opt/ruby/bin:$HOMEBREW_PREFIX/opt/go/bin:$HOMEBREW_PREFIX/opt/python@3/bin:$HOMEBREW_PREFIX/opt/python@3/libexec/bin:$HOMEBREW_PREFIX/opt/openjdk/bin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/bin:$HOMEBREW_PREFIX/opt/findutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-indent/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-which/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$HOMEBREW_PREFIX/opt/m4/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/file-formula/bin:$HOMEBREW_PREFIX/opt/apr/bin:$HOMEBREW_PREFIX/opt/unzip/bin:$HOMEBREW_PREFIX/opt/ssh-copy-id/bin:$HOMEBREW_PREFIX/opt/util-linux/bin:$HOMEBREW_PREFIX/opt/util-linux/sbin:$HOMEBREW_PREFIX/opt/postgresql@16/bin:$HOME/bin:$CARGO_HOME/bin:$FLUTTER_ROOT/bin:$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin"
+export PATH="$HOMEBREW_PREFIX/opt/libxml2/bin:$HOMEBREW_PREFIX/opt/libxslt/bin:$HOMEBREW_PREFIX/opt/libiconv/bin:$HOMEBREW_PREFIX/opt/openssl@3/bin:$HOMEBREW_PREFIX/opt/bison/bin:$HOMEBREW_PREFIX/opt/libressl/bin:$HOMEBREW_PREFIX/opt/curl/bin:$HOMEBREW_PREFIX/opt/sqlite/bin:$HOMEBREW_PREFIX/opt/nss/bin:$HOMEBREW_PREFIX/opt/ruby/bin:$HOMEBREW_PREFIX/opt/go/bin:$HOMEBREW_PREFIX/opt/python@3/bin:$HOMEBREW_PREFIX/opt/python@3/libexec/bin:$HOMEBREW_PREFIX/opt/openjdk/bin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/bin:$HOMEBREW_PREFIX/opt/findutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-indent/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-which/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$HOMEBREW_PREFIX/opt/m4/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/file-formula/bin:$HOMEBREW_PREFIX/opt/apr/bin:$HOMEBREW_PREFIX/opt/unzip/bin:$HOMEBREW_PREFIX/opt/ssh-copy-id/bin:$HOMEBREW_PREFIX/opt/util-linux/bin:$HOMEBREW_PREFIX/opt/util-linux/sbin:$HOMEBREW_PREFIX/opt/postgresql@16/bin:$HOME/bin:$CARGO_HOME/bin:$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin"
 if [ -n "$(echo $CPU_BRAND | grep -o 'Apple')" -a "$(uname -m)" = "arm64" ]; then
   export PATH="$PATH:/usr/local/bin"
 fi
@@ -98,7 +96,5 @@ export GUILE_TLS_CERTIFICATE_DIRECTORY="$HOMEBREW_PREFIX/etc/gnutls/"
 
 export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/opt/openssl@3/lib/pkgconfig"
 export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl@3 --with-libyaml-dir=$HOMEBREW_PREFIX/opt/libyaml --with-libffi-dir=$HOMEBREW_PREFIX/opt/libffi --with-readline-dir=$HOMEBREW_PREFIX/opt/readline --with-gmp-dir=$HOMEBREW_PREFIX/opt/gmp  --enable-yjit"
-
-export FLUTTER_GIT_URL=https://githubmirror.com/flutter.git
 
 export GPG_TTY=$(tty)

--- a/.zsh/variables.zsh
+++ b/.zsh/variables.zsh
@@ -66,9 +66,7 @@ export ASDF_HASHICORP_TERRAFORM_VERSION_FILE=".terraform-version"
 export ENHANCD_DIR="$XDG_DATA_HOME/enhancd"
 export BAT_CONFIG_PATH="$XDG_CONFIG_HOME/bat/config"
 
-export FLUTTER_ROOT="$HOME/Repositories/github.com/flutter/flutter"
-
-export PATH="$HOMEBREW_PREFIX/opt/libxml2/bin:$HOMEBREW_PREFIX/opt/libxslt/bin:$HOMEBREW_PREFIX/opt/libiconv/bin:$HOMEBREW_PREFIX/opt/openssl@3/bin:$HOMEBREW_PREFIX/opt/bison/bin:$HOMEBREW_PREFIX/opt/libressl/bin:$HOMEBREW_PREFIX/opt/curl/bin:$HOMEBREW_PREFIX/opt/sqlite/bin:$HOMEBREW_PREFIX/opt/nss/bin:$HOMEBREW_PREFIX/opt/ruby/bin:$HOMEBREW_PREFIX/opt/go/bin:$HOMEBREW_PREFIX/opt/python@3/bin:$HOMEBREW_PREFIX/opt/python@3/libexec/bin:$HOMEBREW_PREFIX/opt/openjdk/bin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/bin:$HOMEBREW_PREFIX/opt/findutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-indent/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-which/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$HOMEBREW_PREFIX/opt/m4/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/file-formula/bin:$HOMEBREW_PREFIX/opt/apr/bin:$HOMEBREW_PREFIX/opt/unzip/bin:$HOMEBREW_PREFIX/opt/ssh-copy-id/bin:$HOMEBREW_PREFIX/opt/util-linux/bin:$HOMEBREW_PREFIX/opt/util-linux/sbin:$HOMEBREW_PREFIX/opt/postgresql@16/bin:$HOME/bin:$HOME/.docker/bin:$CARGO_HOME/bin:$FLUTTER_ROOT/bin:$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin"
+export PATH="$HOMEBREW_PREFIX/opt/libxml2/bin:$HOMEBREW_PREFIX/opt/libxslt/bin:$HOMEBREW_PREFIX/opt/libiconv/bin:$HOMEBREW_PREFIX/opt/openssl@3/bin:$HOMEBREW_PREFIX/opt/bison/bin:$HOMEBREW_PREFIX/opt/libressl/bin:$HOMEBREW_PREFIX/opt/curl/bin:$HOMEBREW_PREFIX/opt/sqlite/bin:$HOMEBREW_PREFIX/opt/nss/bin:$HOMEBREW_PREFIX/opt/ruby/bin:$HOMEBREW_PREFIX/opt/go/bin:$HOMEBREW_PREFIX/opt/python@3/bin:$HOMEBREW_PREFIX/opt/python@3/libexec/bin:$HOMEBREW_PREFIX/opt/openjdk/bin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/libexec/gnubin:$HOMEBREW_PREFIX/opt/ed/bin:$HOMEBREW_PREFIX/opt/findutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-indent/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-tar/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-which/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$HOMEBREW_PREFIX/opt/m4/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/file-formula/bin:$HOMEBREW_PREFIX/opt/apr/bin:$HOMEBREW_PREFIX/opt/unzip/bin:$HOMEBREW_PREFIX/opt/ssh-copy-id/bin:$HOMEBREW_PREFIX/opt/util-linux/bin:$HOMEBREW_PREFIX/opt/util-linux/sbin:$HOMEBREW_PREFIX/opt/postgresql@16/bin:$HOME/bin:$HOME/.docker/bin:$CARGO_HOME/bin:$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin"
 if [ -n "$(echo $CPU_BRAND | grep -o 'Apple')" -a "$(uname -m)" = "arm64" ]; then
   export PATH="$PATH:/usr/local/bin"
 fi
@@ -106,7 +104,5 @@ export GUILE_TLS_CERTIFICATE_DIRECTORY="$HOMEBREW_PREFIX/etc/gnutls/"
 
 export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/opt/openssl@3/lib/pkgconfig"
 export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl@3 --with-libyaml-dir=$HOMEBREW_PREFIX/opt/libyaml --with-libffi-dir=$HOMEBREW_PREFIX/opt/libffi --with-readline-dir=$HOMEBREW_PREFIX/opt/readline --with-gmp-dir=$HOMEBREW_PREFIX/opt/gmp  --enable-yjit"
-
-export FLUTTER_GIT_URL=https://githubmirror.com/flutter.git
 
 export GPG_TTY=$(tty)

--- a/bin/setup_flutter.sh
+++ b/bin/setup_flutter.sh
@@ -1,21 +1,13 @@
 #!/bin/bash
 set -eu
 
-if [ ! -x "$(command -v ghq)" ]; then
-  echo "Install ghq command first."
-  exit 1
-fi
-
-: "${REPOSITORIES_PATH:=$HOME/Repositories}"
-if [ ! -d "$REPOSITORIES_PATH" ]; then
-  mkdir "$REPOSITORIES_PATH"
-fi
-
-export GHQ_ROOT="${GHQ_ROOT:=$REPOSITORIES_PATH}"
-ghq get --update https://github.com/flutter/flutter
-
-export FLUTTER_ROOT="${FLUTTER_ROOT:=$REPOSITORIES_PATH/github.com/flutter/flutter}"
-git -C $FLUTTER_ROOT switch stable
-$FLUTTER_ROOT/bin/flutter channel stable
-
-unset REPOSITORIES_PATH
+# https://github.com/asdf-community/asdf-flutter/pull/52
+# https://github.com/asdf-community/asdf-flutter/issues/33
+# https://github.com/asdf-community/asdf-flutter/pull/36
+mise plugins install flutter https://github.com/hleinone/asdf-flutter
+mise plugins update flutter
+mise install flutter@latest
+mise upgrade flutter@latest
+mise use --global flutter@latest
+mise prune --yes flutter
+mise reshim


### PR DESCRIPTION
When set up on macOS using asdf-flutter, a zip file is downloaded.
However, asdf-flutter does not support zip files and an error occurs.
There is the Issue and the Pull Request in the repository, but it has not been merged for more than 2 years.
Maybe there is some reason why some environments reproduce the issue and others do not.
Or maybe the repository is not maintained.

See also:
- https://docs.flutter.dev/get-started/install/macos/mobile-ios#download-then-install-flutter
- https://github.com/asdf-community/asdf-flutter/pull/52
- https://github.com/asdf-community/asdf-flutter/issues/33
- https://github.com/asdf-community/asdf-flutter/pull/36