### PR TITLE
Use lazydev.nvim instead of neodev.nvim

### DIFF
--- a/config/nvim/lua/plugins/code.lua
+++ b/config/nvim/lua/plugins/code.lua
@@ -1,6 +1,7 @@
 return {
   {
-    'folke/neodev.nvim',
+    'folke/lazydev.nvim',
+    cond = (not vim.g.vscode),
     lazy = true,
     event = 'VeryLazy',
     opts = {}


### PR DESCRIPTION
neodev.nvim was EOL.

> Development of neodev.nvim is now EOL. If you're on Neovim >= 0.10, then I highly suggest you to use lazydev.nvim It's a much faster and better replacement for neodev.

Refs.
- https://github.com/folke/neodev.nvim/blob/46aa467dca16cf3dfe27098042402066d2ae242d/README.md
- https://github.com/folke/neodev.nvim/pull/155
- https://github.com/folke/lazydev.nvim

In addition, it stop loading on Visual Studio Code, because an error was displayed when it was started.