### PR TITLE
Avoid errors with plugins update command

### DIFF
--- a/bin/setup_go.sh
+++ b/bin/setup_go.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eu
 
-mise plugins update go
 mise install go@latest
 mise upgrade go@latest
 mise use --global go@latest

--- a/bin/setup_java.sh
+++ b/bin/setup_java.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eu
 
-mise plugins update java
 mise install java@latest
 mise upgrade java@latest
 mise use --global java@latest

--- a/bin/setup_nodejs.sh
+++ b/bin/setup_nodejs.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eu
 
-mise plugins update node
 mise install node@lts
 mise upgrade node@lts
 mise install node@latest

--- a/bin/setup_python.sh
+++ b/bin/setup_python.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eu
 
-mise plugins update python
 mise install python@latest
 mise upgrade python@latest
 mise use --global python@latest

--- a/bin/setup_ruby.sh
+++ b/bin/setup_ruby.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eu
 
-mise plugins update ruby
 mise install ruby@latest
 mise upgrade ruby@latest
 mise use --global ruby@latest


### PR DESCRIPTION
Although not mentioned in the documentation, it appears that an error is now displayed when the update command is executed on mise's Core plugins.

Error was:
```
$ mise plugins update ruby --verbose

DEBUG ARGS: /opt/homebrew/bin/mise plugins update ruby --verbose
DEBUG config: ~/.config/mise/config.toml
Error:
   0: unknown plugin type: ruby

Location:
   src/plugins/mod.rs:35

Version:
   2024.11.28 macos-arm64 (2024-11-24)

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Refs.
- https://mise.jdx.dev/plugins.html#core-plugins
- https://mise.jdx.dev/cli/plugins/update.html#mise-plugins-update