### PR TITLE
Re-select the theme of "bat" command

### DIFF
--- a/config/bat/config
+++ b/config/bat/config
@@ -1,2 +1,2 @@
---theme='gruvbox-dark'
+--theme='base16'
 --style='auto'


### PR DESCRIPTION
I chose a theme similar to "tokyonight" I use for Neovim.

Refs.
- https://github.com/sharkdp/bat/blob/dd3d1b8cdb0d089f90420d1ba743b8ead3ad77ad/README.md#highlighting-theme