### PR TITLE
Customize "bat" command with the configuration file

### DIFF
--- a/bin/put_settings.sh
+++ b/bin/put_settings.sh
@@ -30,7 +30,7 @@ if [ ! -d "$XDG_DATA_HOME" ]; then
   mkdir --parents "$XDG_DATA_HOME"
 fi
 
-for app in "git" "starship" "lsd" "sheldon" "bundle" "readline" "gem" "irb" "rspec" "tmux" "tig" "mise" "asdf" "direnv" "aws" "zsh-abbr" "nvim" "wezterm"; do
+for app in "git" "starship" "lsd" "sheldon" "bundle" "readline" "gem" "irb" "rspec" "tmux" "tig" "mise" "asdf" "direnv" "aws" "zsh-abbr" "nvim" "wezterm" "bat"; do
   if [ -L "$XDG_CONFIG_HOME/$app" ]; then
     unlink "$XDG_CONFIG_HOME/$app"
   fi


### PR DESCRIPTION
Use the configuration file.
I had already created a configuration file but forgot to place it under the XDG Base Directory.

Refs.
- https://github.com/sharkdp/bat/blob/dd3d1b8cdb0d089f90420d1ba743b8ead3ad77ad/README.md#configuration-file