### PR TITLE
Remove "Serverless Framework"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -231,7 +231,6 @@ brew install gh
 brew install glab
 brew install heroku
 brew install mongocli
-brew install serverless
 
 # Linters and Code Formatters
 brew install ansible-lint


### PR DESCRIPTION
Serverless Framework V.4 uses proprietary licensed software and is deprecated in Homebrew.

See also:
- https://github.com/Homebrew/homebrew-core/blob/62957dd2f405f48a82046b056ada9a95f9043e6b/Formula/s/serverless.rb#L23-L25
- https://www.serverless.com/framework/docs/guides/upgrading-v4#license-changes