### PR TITLE
Follows renaming font-mplus-nerd-font to font-m+-nerd-font

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -482,7 +482,7 @@ else
   brew install --cask font-monaspace-nerd-font
   brew install --cask font-monoid
   brew install --cask font-monoid-nerd-font
-  brew install --cask font-mplus-nerd-font
+  brew install --cask font-m+-nerd-font
   brew install --cask font-new-york
   brew install --cask font-noto-nerd-font
   brew install --cask font-plemol-jp


### PR DESCRIPTION
```
$ brew info --cask font-mplus-nerd-font

Warning: Cask font-mplus-nerd-font was renamed to font-m+-nerd-font.
==> font-m+-nerd-font: 3.3.0
https://github.com/ryanoasis/nerd-fonts
Installed
/opt/homebrew/Caskroom/font-m+-nerd-font/3.3.0 (306MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/font/font-m/font-m+-nerd-font.rb
```

Refs.
- https://github.com/Homebrew/homebrew-cask/commit/87e1c59a2b0a5b4bb18b0e174fadc857dd1cfe3d
- https://github.com/Homebrew/homebrew-cask/pull/182101