### PR TITLE
Put a blank line after the command output

### DIFF
--- a/bin/setup_java.sh
+++ b/bin/setup_java.sh
@@ -8,3 +8,5 @@ mise prune --yes java
 mise reshim
 
 sudo ln -sfn "$(mise where java@latest)" "/Library/Java/JavaVirtualMachines/openjdk.jdk"
+
+echo


### PR DESCRIPTION
There was no blank line after the output of this command, and it was difficult to read because it stuck to the output result of the next command.