### PR TITLE
Make sure to install "Xcode" before using `xcodebuild` command

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -28,6 +28,8 @@ mas install 411213048 # LadioCast
 mas install 497799835 # Xcode
 mas install 899247664 # TestFlight
 
+sudo xcodebuild -license accept
+
 brew tap Code-Hex/tap
 brew tap auth0/auth0-cli
 brew tap buo/cask-upgrade

--- a/bin/setup_command_line_tools.sh
+++ b/bin/setup_command_line_tools.sh
@@ -5,7 +5,6 @@ COMMAND_LINE_TOOLS_PATH='/Library/Developer/CommandLineTools'
 
 if [ -d "$COMMAND_LINE_TOOLS_PATH/usr/bin" -a -d "$COMMAND_LINE_TOOLS_PATH/SDKs" ]; then
   echo -e "Skip the (re)installation of CommandLineTools.\nSince usr/bin and SDKs directories exist under $COMMAND_LINE_TOOLS_PATH, (re)installation is unlikely to be necessary.\nIf you are forced to re-install, remove those directories before executing the command."
-  sudo xcodebuild -license accept
   exit 0
 fi
 
@@ -32,5 +31,3 @@ tell application "System Events"
 end tell
 EOD
 xcode-select --print-path
-
-sudo xcodebuild -license accept


### PR DESCRIPTION
Avoid the following error.
> xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance