### PR TITLE
Make sure to create "ENHANCD_DIR" beforehand

### DIFF
--- a/bin/put_settings.sh
+++ b/bin/put_settings.sh
@@ -36,6 +36,7 @@ APPS=(
   "bat"
   "bundle"
   "direnv"
+  "enhancd"
   "gem"
   "ghostty"
   "git"


### PR DESCRIPTION
Avoid the following error.
> __enhancd::cd::after:6: no such file or directory: /Users/machupicchubeta/.local/share/enhancd/enhancd.log