### PR TITLE
Sort default-gems -- default RubyGems to install when installing Ruby

### DIFF
--- a/config/mise/ruby/default-gems
+++ b/config/mise/ruby/default-gems
@@ -1,15 +1,15 @@
-tmuxinator
-git-browse-remote
-gem-browse
-refe2
-parser --pre
-rubocop --pre
-gem-ctags
+cocoapods
 fastri
-review
+gem-browse
+gem-ctags
+git-browse-remote
 lolcat
+neovim
+parser --pre
 powder
 reek
-neovim
+refe2
+review
+rubocop --pre
 ruby-lsp
-cocoapods
+tmuxinator


### PR DESCRIPTION
Refs.
- https://mise.jdx.dev/lang/ruby.html#default-gems
- https://mise.jdx.dev/lang/ruby.html#ruby.default_packages_file