### PR TITLE
Render a tab character with two spaces in git diff that using delta (a.k.a. git-delta in Homebrew)

### DIFF
--- a/config/git/conf.d/delta.conf
+++ b/config/git/conf.d/delta.conf
@@ -2,3 +2,4 @@
   line-numbers = true
   syntax-theme = gruvbox-dark
   whitespace-error-style = 22 reverse
+  tabs = 2


### PR DESCRIPTION
Refs.
- https://formulae.brew.sh/formula/git-delta#default
- https://github.com/dandavison/delta?tab=readme-ov-file
- https://dandavison.github.io/delta/full---help-output.html?highlight=tabs#full---help-output

> --tabs <N>
>   The number of spaces to replace tab characters with.
>
>   Use --tabs=0 to pass tab characters through directly, but note that
>   in that case delta will calculate line widths assuming tabs occupy
>   one character's width on the screen: if your terminal renders tabs
>   as more than one character wide then delta's output will look
>   incorrect.
>
>   [default: 8]