### PR TITLE
Show a tab character as "->" in Neovim

### DIFF
--- a/config/nvim/lua/config/options/init.lua
+++ b/config/nvim/lua/config/options/init.lua
@@ -13,6 +13,8 @@ vim.opt.grepprg = 'grep --ignore-case --line-number -H'
 vim.opt.helplang:append({ 'en', 'ja' })
 vim.opt.ignorecase = true
 vim.opt.keywordprg = ':help'
+vim.opt.list = true
+vim.opt.listchars = 'tab:->'
 vim.opt.matchpairs:append('<:>')
 vim.opt.matchtime = 1
 vim.opt.modeline = true


### PR DESCRIPTION
Refs.
- https://neovim.io/doc/user/options.html#'list'
- https://neovim.io/doc/user/options.html#'listchars'