### PR TITLE
Enable `submodule.recurse` in git config

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -72,6 +72,9 @@
   autoupdated = 1
   enabled = 1
 
+[submodule]
+  recurse = true
+
 [url "git://gist.github.com/"]
   insteadOf = "gist:"
 


### PR DESCRIPTION
Enable the setting to automatically perform `git submodule update` equivalent when `git switch` or `git pull` is executed in a directory cloned from a repository using git submodules.

Refs.
- https://git-scm.com/docs/git-config#Documentation/git-config.txt-submodulerecurse
- https://tech.mobilefactory.jp/entry/2022/12/18/000000