### PR TITLE
No longer need to tap "homebrew/bundle" and "homebrew/services"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -36,8 +36,6 @@ brew tap buo/cask-upgrade
 brew tap clementtsang/bottom
 brew tap github/gh
 brew tap heroku/brew
-brew tap homebrew/bundle
-brew tap homebrew/services
 brew tap mongodb/brew
 brew tap olets/tap
 brew tap puma/puma


### PR DESCRIPTION
These taps has been migrate Homebrew main repository.

Error was:
```
Error: homebrew/bundle was deprecated. This tap is now empty and all its contents were either deleted or migrated.
Error: homebrew/services was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

Refs.
- https://github.com/Homebrew/homebrew-bundle/pull/1666
- https://github.com/Homebrew/brew/pull/19487
- https://github.com/Homebrew/homebrew-services/pull/942
- https://github.com/Homebrew/brew/pull/19385