### PR TITLE
Revert "Put a blank line after the command output"

### DIFF
--- a/bin/setup_java.sh
+++ b/bin/setup_java.sh
@@ -8,5 +8,3 @@ mise prune --yes java
 mise reshim
 
 sudo ln -sfn "$(mise where java@latest)" "/Library/Java/JavaVirtualMachines/openjdk.jdk"
-
-echo


### PR DESCRIPTION
This reverts commit af57b33f42270eeff1d3aaab41d2ca735e9bdad6.

The blank line is now included, improving readability.
This commit is no longer needed.