### PR TITLE
Follow changes in Neovim 0.11 and associated changes to mason.nvim 2.0.0 and mason-lspconfig.nvim 2.0.0

### DIFF
--- a/config/nvim/after/lsp/denols.lua
+++ b/config/nvim/after/lsp/denols.lua
@@ -1,0 +1,7 @@
+return {
+  root_makers = {
+    'deno.json',
+    'deno.jsonc'
+  },
+  workspace_required = true
+}

--- a/config/nvim/after/lsp/lua_ls.lua
+++ b/config/nvim/after/lsp/lua_ls.lua
@@ -1,0 +1,9 @@
+return {
+  settings = {
+    Lua = {
+      diagnostics = {
+        globals = { 'vim' }
+      }
+    }
+  },
+}

--- a/config/nvim/after/lsp/ts_ls.lua
+++ b/config/nvim/after/lsp/ts_ls.lua
@@ -1,0 +1,6 @@
+return {
+  root_markers = {
+    'package.json'
+  },
+  workspace_required = true
+}

--- a/config/nvim/lua/plugins/lsp.lua
+++ b/config/nvim/lua/plugins/lsp.lua
@@ -80,7 +80,7 @@ return {
         'lua_ls',
         'marksman',
         'pylsp',
-        'ruby_ls',
+        'ruby_lsp',
         'rust_analyzer',
         'sqlls',
         'svelte',
@@ -89,7 +89,7 @@ return {
         'terraformls',
         'ts_ls',
         'vimls',
-        'vuels',
+        'vue_ls',
         'yamlls',
       }
     },

--- a/config/nvim/lua/plugins/lsp.lua
+++ b/config/nvim/lua/plugins/lsp.lua
@@ -87,7 +87,7 @@ return {
         'stimulus_ls',
         'taplo',
         'terraformls',
-        'tsserver',
+        'ts_ls',
         'vimls',
         'vuels',
         'yamlls',

--- a/config/nvim/lua/plugins/lsp.lua
+++ b/config/nvim/lua/plugins/lsp.lua
@@ -93,53 +93,6 @@ return {
         'yamlls',
       }
     },
-    config = function()
-      local opt = {
-        capabilities = require('cmp_nvim_lsp').default_capabilities(
-          vim.lsp.protocol.make_client_capabilities()
-        )
-      }
-
-      local lspconfig = require('lspconfig')
-
-      require('mason-lspconfig').setup_handlers {
-        function(server)
-          if server == 'denols' then
-            lspconfig.denols.setup(vim.tbl_extend('force', opt, {
-              root_dir = lspconfig.util.root_pattern('deno.json', 'deno.jsonc'),
-              single_file_support = false
-            }))
-          elseif server == 'lua_ls' then
-            lspconfig.lua_ls.setup(vim.tbl_extend('force', opt, {
-              settings = {
-                Lua = {
-                  diagnostics = {
-                    globals = { 'vim' }
-                  }
-                }
-              }
-            }))
-          elseif server == 'tsserver' then
-            lspconfig.tsserver.setup(vim.tbl_extend('force', opt, {
-              root_dir = lspconfig.util.root_pattern('package.json'),
-              single_file_support = false
-            }))
-          elseif server == 'goplus' then
-            lspconfig.gopls.setup(vim.tbl_extend('force', opt, {
-              settings = {
-                goplus = {
-                  env = {
-                    GOFLAGS = '-tags=parallel,serial,integration'
-                  }
-                }
-              }
-            }))
-          else
-            lspconfig[server].setup(opt)
-          end
-        end
-      }
-    end,
     event = 'VeryLazy'
   },
   {


### PR DESCRIPTION
In addition, move the content that overrides `nvim-lspconfig` in the Language Server configuration to `$XDG_CONFIG_HOME/config/nvim/after`.
Only the necessary Language Server settings were moved; the "Go" settings were removed at this time as they are no longer needed.

and renaming and typos of LSPs in the relevant settings were corrected.

Refs.
- https://neovim.io/doc/user/news-0.11.html
- https://github.com/mason-org/mason.nvim/blob/8024d64e1330b86044fed4c8494ef3dcd483a67c/CHANGELOG.md#200-2025-05-06
- https://github.com/mason-org/mason-lspconfig.nvim/blob/c2465eb07db648026eee81005a659abe26e6d077/CHANGELOG.md#200-2025-05-06
- https://github.com/mason-org/mason-lspconfig.nvim/blob/c2465eb07db648026eee81005a659abe26e6d077/README.md#introduction
- https://neovim.io/doc/user/lsp.html#vim.lsp.config()
- https://github.com/mason-org/mason-lspconfig.nvim/issues/544
- https://github.com/LazyVim/LazyVim/issues/6039
- https://zenn.dev/vim_jp/articles/migrate-nvim-lspconfig-v0_11
- https://zenn.dev/kawarimidoll/articles/b202e546bca344
- https://zenn.dev/pandanoir/articles/4736924f5ecc72
- https://zenn.dev/lonsagisawa/articles/nvim11-and-mason