### PR TITLE
Install "OpenAI Codex CLI" via Homebrew instead of "default-npm-packages"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -225,6 +225,7 @@ brew install aws-vault
 brew install awscli
 brew install azure-cli
 brew install circleci
+brew install codex
 brew install doctl
 brew install firebase-cli
 brew install flyctl

--- a/config/mise/node/default-npm-packages
+++ b/config/mise/node/default-npm-packages
@@ -1,4 +1,3 @@
 @anthropic-ai/claude-code
-@openai/codex
 neovim
 npm


### PR DESCRIPTION
With the change from TypeScript CLI to Rust CLI, the official recommended installation method has also changed.

Refs.
- https://github.com/openai/codex/blob/abcca30d93d89197405ec56782e146f7a776297d/README.md
- https://github.com/Homebrew/homebrew-core/pull/228615
- https://github.com/openai/codex/discussions/1405
- https://github.com/openai/codex/commit/abcca30d93d89197405ec56782e146f7a776297d
- https://github.com/machupicchubeta/dotfiles/commit/bfbaee8b2c1f850a9517f1240cd342c77fa44242

```
$ brew info codex

==> codex: stable 0.2.0 (bottled), HEAD
OpenAI's coding agent that runs in your terminal
https://github.com/openai/codex
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/codex.rb
License: Apache-2.0
==> Dependencies
Build: rust ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 1,338 (30 days), 2,067 (90 days), 2,067 (365 days)
install-on-request: 1,338 (30 days), 2,068 (90 days), 2,067 (365 days)
build-error: 5 (30 days)
```