### PR TITLE
Introduce "Gemini CLI"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -229,6 +229,7 @@ brew install codex
 brew install doctl
 brew install firebase-cli
 brew install flyctl
+brew install gemini-cli
 brew install gh
 brew install glab
 brew install heroku


### PR DESCRIPTION
```
$ brew info gemini-cli

==> gemini-cli: stable 0.1.9 (bottled)
Interact with Google Gemini AI models from the command-line
https://github.com/google-gemini/gemini-cli
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/gemini-cli.rb
License: Apache-2.0
==> Dependencies
Required: node ✔
==> Analytics
install: 3,392 (30 days), 3,392 (90 days), 3,392 (365 days)
install-on-request: 3,392 (30 days), 3,392 (90 days), 3,392 (365 days)
build-error: 0 (30 days)
```