### PR TITLE
Introduce "GitHub MCP Server"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -231,6 +231,7 @@ brew install firebase-cli
 brew install flyctl
 brew install gemini-cli
 brew install gh
+brew install github-mcp-server
 brew install glab
 brew install heroku
 brew install mongocli


### PR DESCRIPTION
```
$ brew info github-mcp-server

==> github-mcp-server: stable 0.6.0 (bottled), HEAD
GitHub Model Context Protocol server for AI tools
https://github.com/github/github-mcp-server
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/github-mcp-server.rb
License: MIT
==> Dependencies
Build: go ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 200 (30 days), 505 (90 days), 571 (365 days)
install-on-request: 200 (30 days), 505 (90 days), 571 (365 days)
build-error: 0 (30 days)
```