### PR TITLE
Try to use "Raindrop.io" Safari extensions

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -24,6 +24,7 @@ fi
 brew install mas
 mas purchase 1284863847 # Unsplash Wallpapers
 mas purchase 1295203466 # Microsoft Remote Desktop
+mas purchase 1549370672 # Raindrop.io Safari extensions
 mas purchase 411213048 # LadioCast
 mas purchase 414298354 # ToyViewer
 mas purchase 497799835 # Xcode


### PR DESCRIPTION
```
$ mas info 1549370672

Save to Raindrop.io 5.6.77 [無料]
By: Rustem Mussabekov
Released: 2025-04-08
Minimum OS: 11.0
Size: 1.7 MB
From:
https://apps.apple.com/jp/app/save-to-raindrop-io/id1549370672?mt=12&uo=4
```
