### PR TITLE
Use `mas purchase` instead of `mas install`

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -22,12 +22,12 @@ if [ ! -x "$(command -v brew)" ]; then
 fi
 
 brew install mas
-mas install 1284863847 # Unsplash Wallpapers
-mas install 1295203466 # Microsoft Remote Desktop
-mas install 411213048 # LadioCast
-mas install 414298354 # ToyViewer
-mas install 497799835 # Xcode
-mas install 899247664 # TestFlight
+mas purchase 1284863847 # Unsplash Wallpapers
+mas purchase 1295203466 # Microsoft Remote Desktop
+mas purchase 411213048 # LadioCast
+mas purchase 414298354 # ToyViewer
+mas purchase 497799835 # Xcode
+mas purchase 899247664 # TestFlight
 
 sudo xcodebuild -license accept
 


### PR DESCRIPTION
If I use `mas install`, I get the error the first time I install.
I want to avoid that.

The Error was:
```
Redownload Unavailable with This Apple Account

This redownload is not available for this Apple Account either because it was bought by a different user or the item was refunded or cancelled.
```

Usage:
```
$ mas --help

OVERVIEW: Mac App Store command-line interface

USAGE: mas <subcommand>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  account                 Display the Apple Account signed in to the Mac App Store
  config                  Display mas config & related system info
  home                    Open app's Mac App Store web page in the default web browser
  info                    Display app information from the Mac App Store
  install                 Install previously purchased app(s) from the Mac App Store
  list                    List apps installed from the Mac App Store
  lucky                   Install the first app returned from searching the Mac App Store
                          (app must have been previously purchased)
  open                    Open app page in 'App Store.app'
  outdated                List pending app updates from the Mac App Store
  purchase                "Purchase" and install free apps from the Mac App Store
  region                  Display the region of the Mac App Store
  reset                   Reset Mac App Store running processes
  search                  Search for apps from the Mac App Store
  signin                  Sign in to an Apple Account in the Mac App Store
  signout                 Sign out of the Apple Account currently signed in to the Mac App Store
  uninstall               Uninstall app installed from the Mac App Store
  upgrade                 Upgrade outdated app(s) installed from the Mac App Store
  vendor                  Open vendor's app web page in the default web browser
  version                 Display version number

  See 'mas help <subcommand>' for detailed help.
```
