### PR TITLE
Introduce "1Password" Safari extensions

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -25,6 +25,7 @@ brew install mas
 mas purchase 1284863847 # Unsplash Wallpapers
 mas purchase 1295203466 # Microsoft Remote Desktop
 mas purchase 1549370672 # Raindrop.io Safari extensions
+mas purchase 1569813296 # 1Password Safari extensions
 mas purchase 411213048 # LadioCast
 mas purchase 414298354 # ToyViewer
 mas purchase 497799835 # Xcode


### PR DESCRIPTION
```
$ mas info 1569813296

1Password for Safari 8.10.82 [無料]
By: AgileBits Inc.
Released: 2025-06-25
Minimum OS: 12.0
Size: 60.2 MB
From: https://apps.apple.com/jp/app/1password-for-safari/id1569813296?mt=12&uo=4
```

I had forgotten to include it in the codebase management and had to install it manually.
This should eliminate the need to forget to install it.
