### PR TITLE
Introduce "somo"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -338,6 +338,7 @@ brew install gping
 brew install httpie
 brew install nmap
 brew install nss
+brew install somo
 brew install sqlmap
 brew install sslscan
 brew install stunnel


### PR DESCRIPTION
```
$ brew info somo

==> somo: stable 1.1.0 (bottled)
Human-friendly alternative to netstat for socket and port monitoring
https://github.com/theopfr/somo
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/s/somo.rb
License: MIT
==> Dependencies
Build: rust ✔
==> Analytics
install: 180 (30 days), 181 (90 days), 181 (365 days)
install-on-request: 180 (30 days), 181 (90 days), 181 (365 days)
build-error: 1 (30 days)
```