### PR TITLE
Introduce "zellij"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -187,6 +187,7 @@ brew install starship
 brew install terminal-notifier
 brew install tmux
 brew install z
+brew install zellij
 brew install zsh-abbr
 brew install zsh-autosuggestions
 brew install zsh-completions


### PR DESCRIPTION
```
$ brew info zellij

==> zellij: stable 0.42.2 (bottled), HEAD
Pluggable terminal workspace, with terminal multiplexer as the base feature
https://zellij.dev
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/z/zellij.rb
License: MIT
==> Dependencies
Build: rust ✔
Required: openssl@3 ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 2,153 (30 days), 6,787 (90 days), 34,938 (365 days)
install-on-request: 2,153 (30 days), 6,787 (90 days), 34,938 (365 days)
build-error: 0 (30 days)
```