### PR TITLE
Switch "Moralerspace" font installation from file downloads to via Homebrew

### DIFF
--- a/bin/setup_fonts.sh
+++ b/bin/setup_fonts.sh
@@ -13,34 +13,6 @@ if [ -d "$SOURCE_HAN_CODE_JP_TEMP_DIR" ]; then
   rm --recursive --force "$SOURCE_HAN_CODE_JP_TEMP_DIR"
 fi
 
-echo -e "\nInstall \"Moralerspace\" font families"
-find "$USER_FONT_DIR" -type f -name "Moralerspace*" -exec rm --recursive --force {} +
-MORALERSPACE_FAMILIES=(
-  "Moralerspace"
-  "MoralerspaceHW"
-  "MoralerspaceJPDOC"
-  "MoralerspaceHWJPDOC"
-  "MoralerspaceNF"
-  "MoralerspaceHWNF"
-)
-MORALERSPACE_VERSION="v0.0.11"
-for font_family in "${MORALERSPACE_FAMILIES[@]}"
-do
-  echo -e "\nInstall \"$font_family\" to the user font directory"
-  fonts="$font_family"_"$MORALERSPACE_VERSION"
-  curl --fail --silent --show-error --location https://github.com/yuru7/moralerspace/releases/download/"$MORALERSPACE_VERSION"/"$fonts".zip --output "$TEMP_DIR"/"$fonts".zip
-  unzip -q "$TEMP_DIR"/"$fonts".zip -d "$TEMP_DIR"
-  rm --force "$TEMP_DIR"/"$fonts".zip
-  if [ -d "$TEMP_DIR"/"$fonts" ]; then
-    find "$TEMP_DIR"/"$fonts" -type f -name '*.ttf' -exec mv --target-directory="$USER_FONT_DIR" {} +
-    rm --recursive --force "${TEMP_DIR:?}"/"$fonts"
-  fi
-  unset fonts
-  unset font_family
-done
-
 unset SOURCE_HAN_CODE_JP_TEMP_DIR
 unset TEMP_DIR
 unset USER_FONT_DIR
-unset MORALERSPACE_FAMILIES
-unset MORALERSPACE_VERSION


### PR DESCRIPTION
I had downloaded and installed the file, but since it's available in Homebrew, I'll use that instead.

Refs.
- https://github.com/Homebrew/homebrew-cask/blob/01c72df87f2435edee53ed0744091c0902283533/Casks/font/font-m/font-moralerspace.rb

See also:
- https://github.com/machupicchubeta/dotfiles/commit/98a4db143a01d0f06f18d545ff20b90ad45dc950
- https://github.com/machupicchubeta/dotfiles/pull/607