### PR TITLE
Enable Ruby's idiomatic version files with mise

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -7,3 +7,6 @@ perl = "latest"
 python = "latest"
 ruby = "latest"
 terraform = "latest"
+
+[settings]
+idiomatic_version_file_enable_tools = ["ruby"]


### PR DESCRIPTION
Refs.
- https://mise.jdx.dev/configuration/settings.html#idiomatic_version_file_enable_tools
- https://mise.jdx.dev/configuration.html#idiomatic-version-files

Command is:
- `mise settings add idiomatic_version_file_enable_tools ruby`