### PR TITLE
Install "Heroku CLI" from the homebrew/core tap

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -38,7 +38,6 @@ brew tap auth0/auth0-cli
 brew tap buo/cask-upgrade
 brew tap clementtsang/bottom
 brew tap github/gh
-brew tap heroku/brew
 brew tap mongodb/brew
 brew tap olets/tap
 brew tap puma/puma


### PR DESCRIPTION
Avoid the error when install it via Homebrew.
The error was:
```
Error: heroku was installed from the heroku/brew tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.
```