### PR TITLE
Introduce "iTerm2 Browser Plugin"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -421,6 +421,7 @@ else
   brew install --cask inssider
   brew install --cask iterm2
   brew install --cask itermai
+  brew install --cask itermbrowserplugin
   brew install --cask karabiner-elements
   brew install --cask kiro
   brew install --cask lens


### PR DESCRIPTION
```
$ brew info --cask itermbrowserplugin

==> itermbrowserplugin: 1.0
https://iterm2.com/browser-plugin.html
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/i/itermbrowserplugin.rb
==> Name
iTerm2 Browser Plugin
==> Description
Enables an integrated web browser in iTerm2
==> Artifacts
iTermBrowserPlugin.app (App)
==> Downloading https://formulae.brew.sh/api/cask/itermbrowserplugin.json
==> Analytics
install: 48 (30 days), 49 (90 days), 48 (365 days)
```