### PR TITLE
Remove deprecated apps

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -393,7 +393,6 @@ else
   brew install --cask deepl
   brew install --cask devtoys
   brew install --cask discord
-  brew install --cask disk-inventory-x
   brew install --cask docker-desktop
   brew install --cask dotnet-sdk
   brew install --cask drawio
@@ -408,7 +407,6 @@ else
   brew install --cask fontforge-app
   brew install --cask framer
   brew install --cask gather
-  brew install --cask geektool
   brew install --cask ghostty
   brew install --cask github
   brew install --cask google-chrome
@@ -418,7 +416,6 @@ else
   brew install --cask google-japanese-ime
   brew install --cask gyazo
   brew install --cask hyper
-  brew install --cask inssider
   brew install --cask iterm2
   brew install --cask itermai
   brew install --cask itermbrowserplugin
@@ -446,7 +443,6 @@ else
   brew install --cask reflector
   brew install --cask session-manager-plugin
   brew install --cask sketch
-  brew install --cask skype
   brew install --cask slack
   brew install --cask slack-cli
   brew install --cask spotify


### PR DESCRIPTION
```
$ brew info --cask disk-inventory-x

==> disk-inventory-x: 1.3
https://www.derlien.com/
Deprecated! It will be disabled on 2026-09-01.
Installed
/opt/homebrew/Caskroom/disk-inventory-x/1.3 (20.7MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 04:41:54
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/d/disk-inventory-x.rb
==> Name
Disk Inventory X
==> Description
Disk usage utility
==> Artifacts
Disk Inventory X.app (App)
==> Caveats
disk-inventory-x is built for Intel macOS and so requires Rosetta 2 to be installed.
You can install Rosetta 2 with:
  softwareupdate --install-rosetta --agree-to-license
Note that it is very difficult to remove Rosetta 2 once it is installed.

==> Downloading https://formulae.brew.sh/api/cask/disk-inventory-x.json
==> Analytics
install: 291 (30 days), 888 (90 days), 3,524 (365 days)
```

```
$ brew info --cask geektool

==> geektool: 3.3.1,331.014,1470733752
https://www.tynsoe.org/geektool/
Deprecated because it is not maintained upstream! It will be disabled on 2026-03-31.
Installed
/opt/homebrew/Caskroom/geektool/3.3.1,331.014,1470733752 (15MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 05:07:13
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/g/geektool.rb
==> Name
GeekTool
==> Description
Desktop customization tool
==> Artifacts
GeekTool.app (App)
==> Caveats
geektool is built for Intel macOS and so requires Rosetta 2 to be installed.
You can install Rosetta 2 with:
  softwareupdate --install-rosetta --agree-to-license
Note that it is very difficult to remove Rosetta 2 once it is installed.

==> Downloading https://formulae.brew.sh/api/cask/geektool.json
==> Analytics
install: 44 (30 days), 89 (90 days), 315 (365 days)
```

```
$ brew info --cask inssider

==> inssider: 0.0.4.5
https://www.metageek.com/products/inssider/
Deprecated because it is not maintained upstream! It will be disabled on 2026-03-02.
Installed
/opt/homebrew/Caskroom/inssider/0.0.4.5 (59.8MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 06:06:10
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/i/inssider.rb
==> Name
inSSIDer
==> Description
Defeat slow wifi
==> Artifacts
inSSIDer.app (App)
==> Caveats
inssider is built for Intel macOS and so requires Rosetta 2 to be installed.
You can install Rosetta 2 with:
  softwareupdate --install-rosetta --agree-to-license
Note that it is very difficult to remove Rosetta 2 once it is installed.

==> Downloading https://formulae.brew.sh/api/cask/inssider.json
==> Analytics
install: 11 (30 days), 33 (90 days), 171 (365 days)
```

```
$ brew info --cask skype

==> skype: 8.150.0.125 (auto_updates)
https://www.skype.com/
Deprecated because it is discontinued upstream! It will be disabled on 2026-05-05.
Installed
/opt/homebrew/Caskroom/skype/8.150.0.125 (553.1MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 10:26:41
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/s/skype.rb
==> Name
Skype
==> Description
Video chat, voice call and instant messaging application
==> Artifacts
Skype.app (App)
==> Downloading https://formulae.brew.sh/api/cask/skype.json
==> Analytics
install: 1 (30 days), 4 (90 days), 9,405 (365 days)
```