### PR TITLE
No longer download the unmaintained repository

### DIFF
--- a/bin/download_settings.sh
+++ b/bin/download_settings.sh
@@ -17,7 +17,6 @@ fi
 ghq get --update --parallel github.com/machupicchubeta/laptop
 ghq get --update --parallel github.com/machupicchubeta/dotfiles
 ghq get --update --parallel github.com/machupicchubeta/diceware
-ghq get --update --parallel github.com/altercation/solarized
 ghq get --update --parallel github.com/JonathanSpeek/palenight-iterm2
 ghq get --update --parallel github.com/mbadolato/iTerm2-Color-Schemes
 ghq get --update --parallel github.com/seebi/dircolors-solarized


### PR DESCRIPTION
It hasn't been maintained for about seven years.
- https://github.com/altercation/solarized

The last commit was:
- https://github.com/altercation/solarized/commit/62f656a02f93c5190a8753159e34b385588d5ff3