### PR TITLE
Install "gdb" on arm64 architecture

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -94,10 +94,7 @@ brew install screen
 brew install watch
 brew install wdiff
 brew install wget
-
-if [ "$(uname -m)" = "x86_64" ]; then
-  brew install gdb
-fi
+brew install gdb
 
 # Use the newer version tools instead of the version shipped by macOS
 brew install curl


### PR DESCRIPTION
I noticed that installing "gdb" via Homebrew is also supported on arm64 architecture.

Refs.
- https://github.com/Homebrew/homebrew-core/commit/c8feb61a318c6be9e4f0d7ffd37cd39f2a6b753a
- https://github.com/Homebrew/homebrew-core/pull/209753