### PR TITLE
Remove the unused apps

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -383,7 +383,6 @@ else
   brew install --cask chrome-remote-desktop-host
   brew install --cask chromedriver
   brew install --cask claude
-  brew install --cask clickup
   brew install --cask cloudflare-warp
   brew install --cask container
   brew install --cask coscreen
@@ -396,10 +395,8 @@ else
   brew install --cask docker-desktop
   brew install --cask dotnet-sdk
   brew install --cask drawio
-  brew install --cask dropbox
   brew install --cask dynamodb-local
   brew install --cask encryptme
-  brew install --cask evernote
   brew install --cask figma
   brew install --cask firefox
   brew install --cask firefox@developer-edition
@@ -413,7 +410,6 @@ else
   brew install --cask google-chrome@canary
   brew install --cask google-drive
   brew install --cask google-earth-pro
-  brew install --cask google-japanese-ime
   brew install --cask gyazo
   brew install --cask hyper
   brew install --cask iterm2
@@ -422,15 +418,12 @@ else
   brew install --cask karabiner-elements
   brew install --cask kiro
   brew install --cask lens
-  brew install --cask licecap
   brew install --cask marvel
   brew install --cask messenger
   brew install --cask microsoft-edge
   brew install --cask microsoft-office
-  brew install --cask microsoft-teams
   brew install --cask miro
   brew install --cask mmhmm
-  brew install --cask ngrok
   brew install --cask notion
   brew install --cask notion-calendar
   brew install --cask obsidian
@@ -439,9 +432,7 @@ else
   brew install --cask postman
   brew install --cask raindropio
   brew install --cask raycast
-  brew install --cask reflector
   brew install --cask session-manager-plugin
-  brew install --cask sketch
   brew install --cask slack
   brew install --cask slack-cli
   brew install --cask spotify


### PR DESCRIPTION
```
$ brew info --cask clickup

==> clickup: 3.5.139,250828m7ieelx7h (auto_updates)
https://clickup.com/
Installed
/opt/homebrew/Caskroom/clickup/3.5.139,250828m7ieelx7h (452.2MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 04:17:29
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/clickup.rb
==> Name
ClickUp
==> Description
Productivity platform for tasks, docs, goals, and chat
==> Artifacts
ClickUp.app (App)
==> Downloading https://formulae.brew.sh/api/cask/clickup.json
==> Analytics
install: 191 (30 days), 501 (90 days), 2,156 (365 days)
```

```
$ brew info --cask dropbox

==> dropbox: 233.4.4938 (auto_updates)
https://www.dropbox.com/
Installed
/opt/homebrew/Caskroom/dropbox/233.4.4938 (564.2MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 04:57:06
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/d/dropbox.rb
==> Name
Dropbox
==> Description
Client for the Dropbox cloud storage service
==> Artifacts
Dropbox.app (App)
==> Caveats
dropbox requires a kernel extension to work.
If the installation fails, retry after you enable it in:
  System Settings → Privacy & Security

For more information, refer to vendor documentation or this Apple Technical Note:
  https://developer.apple.com/library/content/technotes/tn2459/_index.html

==> Downloading https://formulae.brew.sh/api/cask/dropbox.json
==> Analytics
install: 1,567 (30 days), 4,111 (90 days), 17,635 (365 days)
```

```
$ brew info --cask evernote

==> evernote: 10.105.4,20240910164757,a2e60a8d876a07eded5d212fa56ba45214114ad0 (auto_updates)
https://evernote.com/
Installed
/opt/homebrew/Caskroom/evernote/10.105.4,20240910164757,a2e60a8d876a07eded5d212fa56ba45214114ad0 (772.3MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 05:00:54
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/e/evernote.rb
==> Name
Evernote
==> Description
App for note taking, organising, task lists, and archiving
==> Artifacts
Evernote.app (App)
==> Downloading https://formulae.brew.sh/api/cask/evernote.json
==> Analytics
install: 107 (30 days), 326 (90 days), 1,677 (365 days)
```

```
$ brew info --cask google-japanese-ime

==> google-japanese-ime: 2.30.5590
https://www.google.co.jp/ime/
Installed
/opt/homebrew/Caskroom/google-japanese-ime/2.30.5590 (68.3MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 05:58:55
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/g/google-japanese-ime.rb
==> Name
Google Japanese Input Method Editor
==> Description
Japanese input software
==> Artifacts
GoogleJapaneseInput.pkg (Pkg)
==> Downloading https://formulae.brew.sh/api/cask/google-japanese-ime.json
==> Analytics
install: 225 (30 days), 830 (90 days), 3,848 (365 days)
```

```
$ brew info --cask licecap

==> licecap: 1.32
https://www.cockos.com/licecap/
Installed
/opt/homebrew/Caskroom/licecap/1.32 (2.1MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 10:12:44
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/l/licecap.rb
==> Name
LICEcap
==> Description
Animated screen capture application
==> Artifacts
LICEcap.app (App)
==> Downloading https://formulae.brew.sh/api/cask/licecap.json
==> Analytics
install: 180 (30 days), 482 (90 days), 2,052 (365 days)
```

```
$ brew info --cask microsoft-teams

==> microsoft-teams: 25240.1603.3956.3103 (auto_updates)
https://www.microsoft.com/en/microsoft-teams/group-chat-software/
Installed
/opt/homebrew/Caskroom/microsoft-teams/25240.1603.3956.3103 (355.5MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 10:20:11
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/m/microsoft-teams.rb
==> Name
Microsoft Teams
==> Description
Meet, chat, call, and collaborate in just one place
==> Dependencies
microsoft-auto-update (cask)
==> Artifacts
MicrosoftTeams.pkg (Pkg)
==> Downloading https://formulae.brew.sh/api/cask/microsoft-teams.json
==> Analytics
install: 4,739 (30 days), 12,768 (90 days), 51,752 (365 days)
```

```
$ brew info --cask ngrok

==> ngrok: 3.30.0,hccQ4GWLNHr,a
https://ngrok.com/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/n/ngrok.rb
==> Name
ngrok
==> Description
Reverse proxy, secure introspectable tunnels to localhost
==> Artifacts
ngrok (Binary)
==> Caveats
To install shell completions, add this to your profile:
  if command -v ngrok &>/dev/null; then
    eval "$(ngrok completion)"
  fi

==> Analytics
install: 29,651 (30 days), 95,033 (90 days), 314,423 (365 days)
```

```
$ brew info --cask reflector

==> reflector: 4.1.2
https://www.airsquirrels.com/reflector/
Installed
/opt/homebrew/Caskroom/reflector/4.1.2 (103.4MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 10:25:32
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/r/reflector.rb
==> Name
Reflector
==> Description
Wireless screen-mirroring application
==> Artifacts
Reflector 4.app (App)
==> Downloading https://formulae.brew.sh/api/cask/reflector.json
==> Analytics
install: 36 (30 days), 75 (90 days), 278 (365 days)
```

```
$ brew info --cask sketch

==> sketch: 2025.2.2,205349 (auto_updates)
https://www.sketch.com/
Installed
/opt/homebrew/Caskroom/sketch/2025.2.2,205349 (176.7MB)
  Installed using the formulae.brew.sh API on 2025-03-03 at 10:25:53
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/s/sketch.rb
==> Name
Sketch
==> Description
Digital design and prototyping platform
==> Artifacts
Sketch.app (App)
==> Downloading https://formulae.brew.sh/api/cask/sketch.json
==> Analytics
install: 202 (30 days), 627 (90 days), 2,378 (365 days)
```