### PR TITLE
Introduce "portless"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -343,6 +343,7 @@ brew install gping
 brew install httpie
 brew install nmap
 brew install nss
+brew install portless
 brew install somo
 brew install sqlmap
 brew install sslscan


### PR DESCRIPTION
```
$ brew info portless
==> portless ✘: stable 0.7.2 (bottled)
Replace port numbers with stable, named local URLs for humans and agents
https://port1355.dev
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/p/portless.rb
License: Apache-2.0
==> Dependencies
Required: node ✔
==> Downloading https://formulae.brew.sh/api/formula/portless.json
==> Analytics
install: 88 (30 days), 88 (90 days), 88 (365 days)
install-on-request: 88 (30 days), 88 (90 days), 88 (365 days)
build-error: 0 (30 days)
```

- https://github.com/vercel-labs/portless