### PR TITLE
Enable `frozen_string_literal` using the environment variable instead of the magic comment

### DIFF
--- a/.bash/env_vars.sh
+++ b/.bash/env_vars.sh
@@ -87,5 +87,6 @@ export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl@3 --
 # export RUBY_YJIT_ENABLE=1
 export RUBY_ZJIT_ENABLE=1
 # export RUBY_BOX=1
+export RUBYOPT='--enable=frozen-string-literal'
 
 export GPG_TTY=$(tty)

--- a/.zsh/env_vars.zsh
+++ b/.zsh/env_vars.zsh
@@ -92,5 +92,6 @@ export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl@3 --
 # export RUBY_YJIT_ENABLE=1
 export RUBY_ZJIT_ENABLE=1
 # export RUBY_BOX=1
+export RUBYOPT='--enable=frozen-string-literal'
 
 export GPG_TTY=$(tty)


### PR DESCRIPTION
Refs.
- https://byroot.github.io/ruby/performance/2025/10/28/string-literals.html
- https://techracho.bpsinc.jp/hachi8833/2025_11_21/154691
- https://bugs.ruby-lang.org/issues/20205#note-35
- https://gist.github.com/fxn/bf4eed2505c76f4fca03ab48c43adc72