### PR TITLE
Introduce Google Antigravity apps

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -370,6 +370,9 @@ brew install --cask aerial
 brew install --cask alfred
 brew install --cask amazon-chime
 brew install --cask android-commandlinetools
+brew install --cask antigravity
+brew install --cask antigravity-cli
+brew install --cask antigravity-ide
 brew install --cask arc
 brew install --cask betterzip
 brew install --cask blackhole-16ch


### PR DESCRIPTION
```
$ brew info --cask antigravity
==> antigravity ✘ (Google Antigravity): 2.0.1,6566078776737792 (auto_updates)
Agent orchestration platform
https://antigravity.google/product/antigravity-2
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/a/antigravity.rb
==> Requirements
Required: macOS >= 12 ✔
==> Artifacts
Antigravity.app (App)
==> Analytics
install: 498 (30 days), 498 (90 days), 498 (365 days)
```

```
$ brew info --cask antigravity-cli
==> antigravity-cli ✘ (Google Antigravity CLI): 1.0.1,5826024320139264 (auto_updates)
Terminal interface for Antigravity agents
https://antigravity.google/product/antigravity-cli
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/a/antigravity-cli.rb
==> Requirements
Required: macOS >= 12 ✔
==> Artifacts
antigravity -> agy (Binary)
==> Analytics
install: 1,571 (30 days), 1,570 (90 days), 1,570 (365 days)
```

```
$ brew info --cask antigravity-ide
==> antigravity-ide ✘ (Google Antigravity IDE): 2.0.3,6242596486512640 (auto_updates)
AI Coding Agent IDE
https://antigravity.google/product/antigravity-ide
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/a/antigravity-ide.rb
==> Requirements
Required: macOS >= 12 ✔
==> Artifacts
Antigravity IDE.app (App)
/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide -> agy-ide (Binary)
/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide (Binary)
==> Analytics
install: 371 (30 days), 371 (90 days), 371 (365 days)
```