### PR TITLE
No longer tapping "clementtsang/bottom" repository

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -26,7 +26,6 @@ mas purchase 899247664 # TestFlight
 brew tap Code-Hex/tap
 brew tap auth0/auth0-cli
 brew tap buo/cask-upgrade
-brew tap clementtsang/bottom
 brew tap github/gh
 brew tap mongodb/brew
 brew tap olets/tap


### PR DESCRIPTION
It's already available for install from the official Homebrew tap.

Refs.
- https://github.com/ClementTsang/homebrew-bottom/blob/b0e58fcb80444b2795b8d05459ae68e846de12e1/README.md
- https://github.com/ClementTsang/bottom/blob/fca070ed08f2f092d732e7d606a2a6497abc4036/README.md#homebrew
- https://formulae.brew.sh/formula/bottom

```
$ brew info bottom
==> bottom ✔: stable 0.12.3 (bottled), HEAD
Yet another cross-platform graphical process/system monitor
https://clementtsang.github.io/bottom/
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/b/bottom.rb
License: MIT
==> Installed Kegs and Versions
bottom ✔ 0.12.3 (13 files, 4MB) [Linked]
==> Options
--HEAD
	Install HEAD version
==> Downloading https://formulae.brew.sh/api/formula/bottom.json
==> Analytics
install: 1,102 (30 days), 3,703 (90 days), 29,045 (365 days)
install-on-request: 1,101 (30 days), 3,702 (90 days), 29,043 (365 days)
build-error: 0 (30 days)
```