### PR TITLE
No longer tapping "github/gh" repository

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -26,7 +26,6 @@ mas purchase 899247664 # TestFlight
 brew tap Code-Hex/tap
 brew tap auth0/auth0-cli
 brew tap buo/cask-upgrade
-brew tap github/gh
 brew tap mongodb/brew
 brew tap olets/tap
 brew tap puma/puma


### PR DESCRIPTION
It's already available for install from the official Homebrew tap.

Refs.
- https://github.com/cli/cli/blob/674e02a56b020549b45f970808ce7c20e179824a/docs/install_macos.md#recommended-official
- https://github.com/Homebrew/homebrew-core/blob/3934cf7db31a8074950f720c848302e2f68746f1/Formula/g/gh.rb
- https://formulae.brew.sh/formula/gh

```
$ brew info gh
==> gh ✔: stable 2.93.0 (bottled), HEAD
GitHub command-line tool
https://cli.github.com/
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/gh.rb
License: MIT
==> Installed Kegs and Versions
gh ✔ 2.93.0 (229 files, 37.9MB) [Linked]
==> Options
--HEAD
	Install HEAD version
==> Downloading https://formulae.brew.sh/api/formula/gh.json
==> Analytics
install: 253,027 (30 days), 904,710 (90 days), 2,576,454 (365 days)
install-on-request: 252,744 (30 days), 903,452 (90 days), 2,572,724 (365 days)
build-error: 811 (30 days)
```