### PR TITLE
No longer tapping "spectralops/tap" repository

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -29,7 +29,6 @@ brew tap buo/cask-upgrade
 brew tap mongodb/brew
 brew tap olets/tap
 brew tap puma/puma
-brew tap spectralops/tap
 brew tap thoughtbot/formulae
 brew tap universal-ctags/universal-ctags
 


### PR DESCRIPTION
`teller` formulae is already available for install from the official Homebrew tap.

Refs.
- https://formulae.brew.sh/formula/teller#default

```
$ brew info teller
==> teller ✔: stable 2.0.7 (bottled), HEAD
Secrets management tool for developers
https://github.com/tellerops/teller
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/teller.rb
License: Apache-2.0
==> Installed Kegs and Versions
teller ✔ 2.0.7 (8 files, 31.5MB) [Linked]
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 7 (30 days), 34 (90 days), 835 (365 days)
install-on-request: 7 (30 days), 34 (90 days), 835 (365 days)
build-error: 0 (30 days)
```