### PR TITLE
No longer tapping "thoughtbot/formulae" repository

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -29,7 +29,6 @@ brew tap buo/cask-upgrade
 brew tap mongodb/brew
 brew tap olets/tap
 brew tap puma/puma
-brew tap thoughtbot/formulae
 brew tap universal-ctags/universal-ctags
 
 brew upgrade --fetch-HEAD


### PR DESCRIPTION
`rcm` formulae is already available for install from the official Homebrew tap.

Refs.
- https://formulae.brew.sh/formula/rcm#default

```
$ brew info rcm
==> rcm ✔: stable 1.3.6 (bottled)
RC file (dotfile) management
https://thoughtbot.github.io/rcm/rcm.7.html
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/r/rcm.rb
License: BSD-3-Clause
==> Installed Kegs and Versions
rcm ✔ 1.3.6 (17 files, 76.7KB) [Linked]
==> Analytics
install: 48 (30 days), 192 (90 days), 765 (365 days)
install-on-request: 48 (30 days), 192 (90 days), 765 (365 days)
build-error: 0 (30 days)
```