### PR TITLE
No longer tapping "universal-ctags/universal-ctags" repository

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -29,7 +29,6 @@ brew tap buo/cask-upgrade
 brew tap mongodb/brew
 brew tap olets/tap
 brew tap puma/puma
-brew tap universal-ctags/universal-ctags
 
 brew upgrade --fetch-HEAD
 


### PR DESCRIPTION
It's already available for install from the official Homebrew tap.'

Refs.
- https://formulae.brew.sh/formula/universal-ctags#default
- https://github.com/universal-ctags/homebrew-universal-ctags/commit/c84df0fc89f3a63ce5438eb59244ec2080352c0d

```
$ brew info universal-ctags
==> universal-ctags ✔: stable 6.2.1 (bottled), HEAD
Maintained ctags implementation
https://ctags.io/
Conflicts with:
  ctags (because both install `ctags` binaries)
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/u/universal-ctags.rb
License: GPL-2.0-or-later
==> Installed Kegs and Versions
universal-ctags ✔ HEAD-e6a4947 (52 files, 4.1MB)
universal-ctags ✔ 6.2.1        (52 files, 4MB)   [Linked]
==> Dependencies
Build (3): docutils ✔, pkgconf ✔, python@3.14 ✔
Required (3): jansson ✔, libyaml ✔, pcre2 ✔
Recursive Runtime (3): all installed ✔
==> Options
--HEAD
	Install HEAD version
==> Downloading https://formulae.brew.sh/api/formula/universal-ctags.json
==> Analytics
install: 558 (30 days), 1,701 (90 days), 25,242 (365 days)
install-on-request: 489 (30 days), 1,526 (90 days), 21,937 (365 days)
build-error: 0 (30 days)
```