### PR TITLE
No longer need to install HEAD version; Use each release version

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -104,8 +104,7 @@ brew install rustup-init
 # brew install rust # This is installed in a library paragraph.
 brew install ruby-build
 brew install ruby
-brew install node-build --HEAD
-brew link node-build
+brew install node-build
 brew install node
 brew install openjdk
 brew install kotlin


### PR DESCRIPTION
Since I install Node.js for product development using mise, each release version installed via Homebrew is sufficient.

This revert the following commits.
- https://github.com/machupicchubeta/dotfiles/commit/9ea59be6898f3ca1cd14395a7323c02984dbc038
- https://github.com/machupicchubeta/dotfiles/commit/1eef29be4d7d91f776ddeb1cc7c40d5cba062f59