### PR TITLE
No longer need to install HEAD version; Use each release version

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -26,8 +26,6 @@ mas purchase 899247664 # TestFlight
 brew tap buo/cask-upgrade
 brew trust --command buo/cask-upgrade/cu
 
-brew upgrade --fetch-HEAD
-
 # Libraries that used in Ruby or so, or used to build from source code
 ## This paragraph is arranged in the order in which they need to be installed.
 brew install openssl@3
@@ -163,8 +161,7 @@ brew install emacs
 brew install nano
 brew install source-highlight
 brew install swift
-brew install universal-ctags --HEAD
-brew link universal-ctags
+brew install universal-ctags
 brew install vim
 brew install xcodesorg/made/xcodes
 


### PR DESCRIPTION
It used to be a "head-only" formulae, but that is no longer the case since it was migrated into Homebrew core.

Refs.
- https://formulae.brew.sh/formula/universal-ctags#default

This revert the following commits.
- https://github.com/machupicchubeta/dotfiles/commit/39d8fbbeec239380c04d1684bb0890178dc94e9d
- https://github.com/machupicchubeta/dotfiles/commit/63b4ae0d1f5a46bfce0287621f592ea5cdb11391