### PR TITLE
Install not only MongoDB Community Server but also MongoDB Database Tools

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -191,6 +191,7 @@ brew install the_silver_searcher
 # Data stores
 brew install memcached
 brew install mongodb/brew/mongodb-community
+brew install mongodb/brew/mongodb-database-tools
 brew install mysql
 brew install postgresql@16
 brew install redis


### PR DESCRIPTION
Avoid the untrusted tap error.
Error was:
```
Error: Refusing to load formula mongodb/brew/mongodb-database-tools from untrusted tap mongodb/brew.
Run `brew trust --formula mongodb/brew/mongodb-database-tools` or `brew trust mongodb/brew` to trust it.
```