### PR TITLE
Remove "Gemini CLI"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -222,7 +222,6 @@ brew install copilot
 brew install doctl
 brew install firebase-cli
 brew install flyctl
-brew install gemini-cli
 brew install gh
 brew install github-mcp-server
 brew install glab


### PR DESCRIPTION
Google said "Transitioning Gemini CLI to Antigravity CLI".
Since I already installed Antigravity CLI, remove Gemini CLI.

Refs.
- https://github.com/Homebrew/homebrew-core/commit/192ecb9f945c93423770cb0e76bce7d62dc0d872
- https://github.com/Homebrew/homebrew-core/pull/284420
- https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/