### PR TITLE
Remove "The Silver Searcher" that is no longer maintained

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -186,7 +186,6 @@ brew install peco
 brew install pick
 brew install ripgrep
 brew install ripgrep-all
-brew install the_silver_searcher
 
 # Data stores
 brew install memcached

--- a/config/nvim/lua/plugins/search.lua
+++ b/config/nvim/lua/plugins/search.lua
@@ -38,7 +38,6 @@ return {
       require('telescope').load_extension('file_browser')
       require('telescope').load_extension('lazy')
       require('telescope').load_extension('fzf')
-      require('telescope').load_extension('ag')
       require('telescope').load_extension('dir')
       require('telescope').load_extension('dap')
       require('telescope').load_extension('git_grep')
@@ -72,18 +71,6 @@ return {
     lazy = true,
     build = 'make',
     event = 'VeryLazy'
-  },
-  {
-    'kelly-lin/telescope-ag',
-    cond = (not vim.g.vscode),
-    lazy = true,
-    config = function()
-      local telescope_ag = require('telescope-ag')
-      telescope_ag.setup({
-        cmd = telescope_ag.cmds.ag
-      })
-    end,
-    cmd = 'Ag'
   },
   {
     'princejoogie/dir-telescope.nvim',


### PR DESCRIPTION
The latest commit is about 6 years ago.

For that purpose, I've decided to use "ripgrep" from now on. Apparently, it's faster.

Refs.
- https://formulae.brew.sh/formula/the_silver_searcher
- https://github.com/ggreer/the_silver_searcher
- https://github.com/kelly-lin/telescope-ag
- https://github.com/nvim-telescope/telescope.nvim
- https://github.com/burntsushi/ripgrep