### PR TITLE
Remove the disabled formula "icu4c@76" and any formulae that use it

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -159,7 +159,6 @@ brew install neovide
 brew install cscope
 brew install emacs
 brew install nano
-brew install source-highlight
 brew install swift
 brew install universal-ctags
 brew install vim
@@ -255,7 +254,6 @@ brew install grex
 brew install gti
 brew install hyperfine
 brew install install-nothing
-brew install ios-sim
 brew install iso-codes
 brew install jless
 brew install jq
@@ -267,7 +265,6 @@ brew install pv
 brew install screenfetch
 brew install sd
 brew install shared-mime-info
-brew install silicon
 brew install spark
 brew install ssh-copy-id
 brew install terraform_landscape


### PR DESCRIPTION
I don't use them on a regular basis, so I think it's fine to remove them.

Refs.
- https://github.com/Homebrew/homebrew-core/blob/8dcc072b72f0f61c3dd0534aa3f4f83f1ede96e8/Formula/i/icu4c@76.rb


```
$ brew doctor

... (omit) ...

Warning: Some installed formulae are deprecated or disabled.
You should find replacements for the following formulae:
  icu4c@76

... (omit) ...
```

```
$ brew uninstall icu4c@76
Error: Refusing to uninstall /opt/homebrew/Cellar/icu4c@76/76.1_2
because it is required by ios-sim, silicon and source-highlight, which are currently installed.
You can override this and force removal with:
  brew uninstall --ignore-dependencies icu4c@76
```