### PR TITLE
Avoid the Rust panic by revising Starship's `time_format` settings

### DIFF
--- a/config/starship/config.toml
+++ b/config/starship/config.toml
@@ -94,5 +94,5 @@ style = "dimmed white"
 
 [time]
 disabled = false
-time_format = "%+"
+time_format = "%F%T%.f%:z"
 style = "dimmed white"


### PR DESCRIPTION
The "panic" was:
```
thread '<unnamed>' (928321) panicked at /opt/homebrew/Cellar/rust/1.96.0/lib/rustlib/src/rust/library/alloc/src/string.rs:2916:14:
a Display implementation returned an error unexpectedly: Error
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

In Starship 1.26.0, the library used for settings such as `time_format` was changed from "chrono" to "jiff".

When configuring ISO 8601 / RFC 3339 date and time formats, "chrono" supported the use of `%+`. But "jiff" does not support `%+`, so I need to rewrite the configuration to express the same content.

Refs.
- https://github.com/starship/starship/commit/3dd8c1414476b139a7e5a73e27fb6e1402ed4c79
- https://github.com/starship/starship/pull/7222
- https://github.com/starship/starship/releases/tag/v1.26.0
- https://docs.rs/chrono/latest/chrono/format/strftime/#fn7
- https://docs.rs/jiff/latest/jiff/fmt/strtime/index.html#unsupported