### PR TITLE
Remove "Codex.app" that is discontinued

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -371,7 +371,6 @@ brew install --cask claude-code
 brew install --cask cloudflare-warp
 brew install --cask cmux
 brew install --cask codex
-brew install --cask codex-app
 brew install --cask coscreen
 brew install --cask cursor
 brew install --cask cyberduck


### PR DESCRIPTION
"Codex.app" has been merged into "ChatGPT.app" and is discontinued as a standalone app.

Refs.
- https://learn.chatgpt.com/docs/changelog#codex-2026-07-09-app
- https://x.com/CodexReleases/status/2075265220054782386
- https://github.com/Homebrew/homebrew-cask/commit/d242d36552b9461890435ffff398816c1101418e
- https://github.com/Homebrew/homebrew-cask/pull/274610