### PR TITLE
Rename the previous "ChatGPT" desktop app to "ChatGPT Classic"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -364,6 +364,7 @@ brew install --cask blisk
 brew install --cask brave-browser
 brew install --cask canva
 brew install --cask chatgpt
+brew install --cask chatgpt-classic
 brew install --cask chrome-remote-desktop-host
 brew install --cask chromedriver
 brew install --cask claude


### PR DESCRIPTION
 Refs.
 - https://help.openai.com/en/articles/20001276-moving-to-the-new-chatgpt-desktop-app
 - https://github.com/Homebrew/homebrew-cask/commit/e6fbb20184ec1344fa89a0d08cce8b7ba433af0b
 - https://github.com/Homebrew/homebrew-cask/pull/274342