### PR TITLE
Remove "Arc.app" that is discontinued

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -355,7 +355,6 @@ brew install --cask android-commandlinetools
 brew install --cask antigravity
 brew install --cask antigravity-cli
 brew install --cask antigravity-ide
-brew install --cask arc
 brew install --cask betterzip
 brew install --cask blackhole-16ch
 brew install --cask blackhole-2ch


### PR DESCRIPTION
It was announced in May 2025 that development of "Arc.app" had been discontinued.
It was also announced that "Dia.app" was being developed as its successor, but since it hadn't been officially released at that time, I left the app as is on my mac.
Upon seeing that "Dia.app" had been officially released in October 2025, I decided to uninstall "Arc.app."

Refs.
- https://browsercompany.substack.com/p/letter-to-arc-members-2025
- https://x.com/diabrowser/status/1975923799498383806