### PR TITLE
Remove "FontForge.app"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -387,7 +387,6 @@ brew install --cask figma
 brew install --cask firefox
 brew install --cask firefox@developer-edition
 brew install --cask fliqlo
-brew install --cask fontforge-app
 brew install --cask framer
 brew install --cask gather
 brew install --cask ghostty


### PR DESCRIPTION
I installed it just to try it out, but since I don't create my own fonts, I never ended up using it.
Since "FontForge.app" is an unsigned app and has been marked as deprecated by Homebrew, I'm going to remove it from my Mac now.

Refs.
- https://github.com/Homebrew/homebrew-cask/commit/643cd0dbb28c7b7d3ad9920a43f73fdac60a44f1
- https://github.com/fontforge/fontforge/issues/5112
- https://github.com/Homebrew/brew/issues/20755
- https://support.apple.com/ja-jp/guide/security/sec5599b66df/web