### PR TITLE
Remove "AWS Copilot CLI"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -216,7 +216,6 @@ brew install aws-vault
 brew install awscli
 brew install azure-cli
 brew install circleci
-brew install copilot
 brew install doctl
 brew install firebase-cli
 brew install flyctl


### PR DESCRIPTION
It has been reach end of support on June 12, 2026.

Refs.
- https://aws.github.io/copilot-cli/
- https://aws.amazon.com/blogs/containers/announcing-the-end-of-support-for-the-aws-copilot-cli/
- https://github.com/aws/copilot-cli/blob/a0dbe68908e55c4292e5838bd6cfbaea38364879/README.md#warning-upcoming-end-of-support-warning
- https://github.com/Homebrew/homebrew-core/commit/812c553e5d5d25def5d36e88bc9da45805e40050
- https://github.com/Homebrew/homebrew-core/pull/291493