### PR TITLE
Remove "ttyrec"

### DIFF
--- a/bin/brewfile.sh
+++ b/bin/brewfile.sh
@@ -342,7 +342,6 @@ brew install tlrc
 # Audio and Video tools
 brew install ffmpeg
 brew install lame
-brew install ttyrec
 brew install x265
 
 brew install --cask 1password


### PR DESCRIPTION
This software is no longer maintained.
If my future self wants to use similar functionality, it seems a good idea to install "ovh-ttyrec".

Refs.
- https://0xcc.net/ttyrec/
- https://github.com/Homebrew/homebrew-core/blob/6ae532c820ba2691464b92eb3e27f79f676c69b0/Formula/t/ttyrec.rb
- https://github.com/Homebrew/homebrew-core/pull/293798

About "ovh-ttyrec" :
- https://formulae.brew.sh/formula/ovh-ttyrec#default
- https://github.com/ovh/ovh-ttyrec